### PR TITLE
feat: add HTTP health probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,24 @@ metrics:
 
 All per-GPU metrics are labeled with `gpu_index`, `gpu_uuid`, and `gpu_name`.
 
+## Kubernetes Probes
+
+The scaler exposes liveness and readiness endpoints on a dedicated probe port:
+
+- `/healthz` returns `200` while the process is alive.
+- `/readyz` returns `200` after NVML initializes and the first metrics collection succeeds.
+
+```bash
+--probe-port=8081
+```
+
+Helm:
+```yaml
+probes:
+  enabled: true
+  port: 8081
+```
+
 ---
 
 ## Build it Yourself

--- a/cmd/keda-gpu-scaler/main.go
+++ b/cmd/keda-gpu-scaler/main.go
@@ -37,12 +37,14 @@ import (
 	pb "github.com/pmady/keda-gpu-scaler/pkg/externalscaler"
 	"github.com/pmady/keda-gpu-scaler/pkg/gpu"
 	"github.com/pmady/keda-gpu-scaler/pkg/metrics"
+	"github.com/pmady/keda-gpu-scaler/pkg/probes"
 	"github.com/pmady/keda-gpu-scaler/pkg/scaler"
 )
 
 var (
 	port        = flag.Int("port", 6000, "gRPC server port")
 	metricsPort = flag.Int("metrics-port", 9090, "Prometheus metrics HTTP port (0 to disable)")
+	probePort   = flag.Int("probe-port", 8081, "Health/readiness HTTP port (0 to disable)")
 	logLevel    = flag.String("log-level", "info", "Log level (debug, info, warn, error)")
 )
 
@@ -55,8 +57,22 @@ func main() {
 	logger.Info("Starting keda-gpu-scaler",
 		zap.Int("port", *port),
 		zap.Int("metricsPort", *metricsPort),
+		zap.Int("probePort", *probePort),
 		zap.String("logLevel", *logLevel),
 	)
+
+	var probeState probes.State
+	if *probePort > 0 {
+		probeAddr := fmt.Sprintf(":%d", *probePort)
+		go func() {
+			logger.Info("Probe server listening", zap.String("address", probeAddr))
+			if err := http.ListenAndServe(probeAddr, probes.Handler(&probeState)); err != nil && err != http.ErrServerClosed {
+				logger.Fatal("Probe server failed", zap.Error(err))
+			}
+		}()
+	} else {
+		logger.Info("Probe server disabled (probe-port=0)")
+	}
 
 	// Initialize NVML GPU collector
 	collector, err := gpu.NewCollector(logger)
@@ -77,9 +93,6 @@ func main() {
 
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
-		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		})
 		metricsAddr := fmt.Sprintf(":%d", *metricsPort)
 		go func() {
 			logger.Info("Prometheus metrics server listening", zap.String("address", metricsAddr))
@@ -112,6 +125,7 @@ func main() {
 				zap.Uint64("memTotalMiB", m.MemoryTotalMiB),
 			)
 		}
+		probeState.MarkReady()
 	}
 
 	// Start gRPC server

--- a/deploy/helm/keda-gpu-scaler/templates/daemonset.yaml
+++ b/deploy/helm/keda-gpu-scaler/templates/daemonset.yaml
@@ -40,6 +40,11 @@ spec:
             {{- else }}
             - --metrics-port=0
             {{- end }}
+            {{- if .Values.probes.enabled }}
+            - --probe-port={{ .Values.probes.port }}
+            {{- else }}
+            - --probe-port=0
+            {{- end }}
           ports:
             - name: grpc
               containerPort: {{ .Values.grpc.port }}
@@ -49,18 +54,27 @@ spec:
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.probes.enabled }}
+            - name: probes
+              containerPort: {{ .Values.probes.port }}
+              protocol: TCP
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.probes.enabled }}
           livenessProbe:
-            grpc:
-              port: {{ .Values.grpc.port }}
+            httpGet:
+              path: /healthz
+              port: probes
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
-            grpc:
-              port: {{ .Values.grpc.port }}
+            httpGet:
+              path: /readyz
+              port: probes
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.nvmlHostMounts.enabled }}

--- a/deploy/helm/keda-gpu-scaler/values.yaml
+++ b/deploy/helm/keda-gpu-scaler/values.yaml
@@ -28,6 +28,10 @@ metrics:
   enabled: true
   port: 9090
 
+probes:
+  enabled: true
+  port: 8081
+
 nodeSelector:
   nvidia.com/gpu.present: "true"
 

--- a/deploy/manifests.yaml
+++ b/deploy/manifests.yaml
@@ -78,12 +78,16 @@ spec:
             - "--port=6000"
             - "--log-level=info"
             - "--metrics-port=9090"
+            - "--probe-port=8081"
           ports:
             - name: grpc
               containerPort: 6000
               protocol: TCP
             - name: metrics
               containerPort: 9090
+              protocol: TCP
+            - name: probes
+              containerPort: 8081
               protocol: TCP
           # NVML requires root + access to the host's NVIDIA device files.
           securityContext:
@@ -97,13 +101,15 @@ spec:
               cpu: 200m
               memory: 128Mi
           livenessProbe:
-            grpc:
-              port: 6000
+            httpGet:
+              path: /healthz
+              port: probes
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
-            grpc:
-              port: 6000
+            httpGet:
+              path: /readyz
+              port: probes
             initialDelaySeconds: 3
             periodSeconds: 5
           volumeMounts:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,6 +93,7 @@ These flags configure the scaler binary itself (passed via `args` in the DaemonS
 |------|-------------|---------|
 | `--port` | gRPC server port | `6000` |
 | `--metrics-port` | Prometheus HTTP metrics port (0 to disable) | `9090` |
+| `--probe-port` | Liveness/readiness HTTP probe port (0 to disable) | `8081` |
 | `--log-level` | Log level: `debug`, `info`, `warn`, `error` | `info` |
 
 ### Helm Values
@@ -105,12 +106,16 @@ metrics:
   enabled: true    # set to false to disable Prometheus endpoint
   port: 9090
 
+probes:
+  enabled: true
+  port: 8081
+
 logLevel: info
 ```
 
 ## Prometheus Metrics
 
-When `--metrics-port` is non-zero, an HTTP server exposes `/metrics` (Prometheus format) and `/healthz`. This is optional and does not affect the KEDA scaling path.
+When `--metrics-port` is non-zero, an HTTP server exposes `/metrics` in Prometheus format. This is optional and does not affect the KEDA scaling path.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
@@ -124,6 +129,13 @@ When `--metrics-port` is non-zero, an HTTP server exposes `/metrics` (Prometheus
 | `keda_gpu_scaler_collection_duration_seconds` | Histogram | — | NVML collection latency |
 | `keda_gpu_scaler_scaler_requests_total` | Counter | `method` | gRPC requests by method |
 | `keda_gpu_scaler_scaler_request_errors_total` | Counter | `method` | gRPC errors by method |
+
+## Kubernetes Probes
+
+When `--probe-port` is non-zero, an HTTP server exposes:
+
+- `/healthz` — returns 200 while the scaler process is alive.
+- `/readyz` — returns 200 after NVML initializes and the first metrics collection succeeds.
 
 ## Examples
 

--- a/pkg/probes/probes.go
+++ b/pkg/probes/probes.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 The keda-gpu-scaler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// State tracks the readiness state exposed by the probe handler.
+type State struct {
+	ready atomic.Bool
+}
+
+// MarkReady records that the scaler has completed its first successful metrics
+// collection and can serve traffic.
+func (s *State) MarkReady() {
+	s.ready.Store(true)
+}
+
+// Ready reports whether the scaler is ready to serve traffic.
+func (s *State) Ready() bool {
+	return s.ready.Load()
+}
+
+// Handler returns an HTTP handler for Kubernetes liveness/readiness probes.
+func Handler(state *State) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if !state.Ready() {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	return mux
+}

--- a/pkg/probes/probes_test.go
+++ b/pkg/probes/probes_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The keda-gpu-scaler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package probes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler(t *testing.T) {
+	var state State
+	handler := Handler(&state)
+
+	tests := []struct {
+		name string
+		path string
+		want int
+	}{
+		{name: "health always ok", path: "/healthz", want: http.StatusOK},
+		{name: "ready starts unavailable", path: "/readyz", want: http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Fatalf("%s returned status %d, want %d", tt.path, rec.Code, tt.want)
+			}
+		})
+	}
+
+	state.MarkReady()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/readyz after MarkReady returned status %d, want %d", rec.Code, http.StatusOK)
+	}
+}


### PR DESCRIPTION
Adds dedicated Kubernetes probe endpoints for #46.

What changed:
- adds a small `pkg/probes` HTTP handler
- starts a separate probe server on `--probe-port` (default `8081`)
- `/healthz` returns 200 while the process is alive
- `/readyz` returns 200 after NVML initializes and the first metrics collection succeeds
- updates the raw DaemonSet and Helm chart to use HTTP liveness/readiness probes on the probe port
- documents the new flag and Helm values

Local checks:
- `cmd /c "go test ./pkg/probes -count=1 -v"`
- `git diff --check`

I could not run the full `make test` or Helm render locally on this Windows machine. The full package test path hangs in the NVML-related packages here, and `helm` is not installed.

Fixes #46