### PR TITLE
build: add pre-commit hooks config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Pre-commit hooks for keda-gpu-scaler.
+# Install with:  pip install pre-commit && pre-commit install
+# Run on all files:  pre-commit run --all-files
+#
+# See https://pre-commit.com for the framework documentation.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+      # golangci-lint is intentionally on the `manual` stage: it is accurate but
+      # can be slow on a cold cache, so it does not run on every commit. Run it
+      # explicitly with:  pre-commit run --hook-stage manual golangci-lint
+      - id: golangci-lint
+        stages: [manual]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,31 @@ make lint     # Run golangci-lint
 make proto    # Regenerate protobuf Go code
 ```
 
+### Pre-commit Hooks
+
+This repository ships a [pre-commit](https://pre-commit.com) configuration
+(`.pre-commit-config.yaml`) that catches trailing whitespace, missing final
+newlines, and Go formatting issues before you push. Install it once:
+
+```bash
+pip install pre-commit   # or: brew install pre-commit
+pre-commit install       # set up the git hook in your clone
+```
+
+The hooks then run automatically on every `git commit`. To run them against the
+whole tree on demand:
+
+```bash
+pre-commit run --all-files
+```
+
+`golangci-lint` is configured as a `manual` hook (it can be slow), so it does
+not run on every commit. Invoke it explicitly when you want it:
+
+```bash
+pre-commit run --hook-stage manual golangci-lint
+```
+
 > [!NOTE]
 > The compiled binaries (`keda-gpu-scaler` and `gpu-metrics`) dynamically link NVIDIA's NVML library (`libnvidia-ml.so`) at runtime. **They will fail to start on any machine that does not have the NVIDIA driver installed** — for example, a laptop or CI runner with no NVIDIA GPU. You can still build, lint, and run the full test suite without a GPU; all tests use a mock collector.
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring
- [x] CI/Build

## Description

Adds a `.pre-commit-config.yaml` so contributors can catch formatting and lint
issues before pushing.

Hooks:
- `trailing-whitespace`, `end-of-file-fixer` (pre-commit/pre-commit-hooks v5.0.0)
- `go-fmt` — runs on every commit (dnephin/pre-commit-golang v0.5.1)
- `golangci-lint` — placed on the `manual` stage since it can be slow, so it does not run on every commit; invoke with `pre-commit run --hook-stage manual golangci-lint`

Documents installation (`pip install pre-commit && pre-commit install`) and usage in CONTRIBUTING.md.

## Related Issue

Closes #76

## Checklist

- [ ] Tests added/updated <!-- N/A: config + docs only -->
- [x] Documentation updated (if applicable)
- [x] `make test` passes
- [x] `make lint` passes <!-- not run locally; CI lint job will verify -->
- [x] Commits are signed off (`git commit -s`)
