### PR TITLE
build: add fmt and check-fmt targets, gate CI on formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,9 @@ jobs:
         with:
           go-version: '1.25'
 
+      - name: Check formatting
+        run: make check-fmt
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build proto test test-e2e lint clean docker-build docker-push docker-release deploy undeploy helm-lint helm-template helm-test help
+.PHONY: build proto test test-e2e fmt check-fmt lint clean docker-build docker-push docker-release deploy undeploy helm-lint helm-template helm-test help
 
 BINARY_NAME := keda-gpu-scaler
 IMAGE_REPO := ghcr.io/pmady/keda-gpu-scaler
@@ -27,6 +27,17 @@ test: ## Run unit tests
 
 test-e2e: ## Run e2e integration tests (no GPU required — uses mock collector)
 	go test -v -tags=e2e -race ./tests/e2e/...
+
+fmt: ## Format Go source files
+	go fmt ./...
+
+check-fmt: ## Check formatting without modifying files (fails if any file needs gofmt)
+	@unformatted=$$(gofmt -l .); \
+	if [ -n "$$unformatted" ]; then \
+		echo "Files need formatting (run 'make fmt'):"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
 
 lint: ## Run linter
 	golangci-lint run ./...

--- a/cmd/gpu-metrics/main.go
+++ b/cmd/gpu-metrics/main.go
@@ -34,11 +34,11 @@ import (
 )
 
 var (
-	format  = flag.String("format", "table", "Output format: table, json, csv")
+	format   = flag.String("format", "table", "Output format: table, json, csv")
 	interval = flag.Duration("interval", 0, "Collection interval (0 = one-shot)")
-	device  = flag.Int("device", -1, "GPU device index (-1 = all)")
-	quiet   = flag.Bool("quiet", false, "Suppress log output")
-	envFlag = flag.String("env", "auto", "Environment: auto, k8s, slurm, flux, standalone")
+	device   = flag.Int("device", -1, "GPU device index (-1 = all)")
+	quiet    = flag.Bool("quiet", false, "Suppress log output")
+	envFlag  = flag.String("env", "auto", "Environment: auto, k8s, slurm, flux, standalone")
 )
 
 func main() {

--- a/cmd/keda-gpu-scaler/main.go
+++ b/cmd/keda-gpu-scaler/main.go
@@ -34,8 +34,8 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
-	pb "github.com/pmady/keda-gpu-scaler/pkg/externalscaler"
 	"github.com/pmady/keda-gpu-scaler/pkg/env"
+	pb "github.com/pmady/keda-gpu-scaler/pkg/externalscaler"
 	"github.com/pmady/keda-gpu-scaler/pkg/gpu"
 	"github.com/pmady/keda-gpu-scaler/pkg/metrics"
 	"github.com/pmady/keda-gpu-scaler/pkg/probes"

--- a/pkg/flux/flux_test.go
+++ b/pkg/flux/flux_test.go
@@ -174,10 +174,10 @@ func TestFromEnv(t *testing.T) {
 		{
 			name: "no CUDA_VISIBLE_DEVICES means no GPUs",
 			env: map[string]string{
-				"FLUX_JOB_ID":      "cpuonly",
-				"FLUX_TASK_RANK":   "0",
-				"FLUX_JOB_SIZE":    "4",
-				"FLUX_JOB_NNODES":  "1",
+				"FLUX_JOB_ID":     "cpuonly",
+				"FLUX_TASK_RANK":  "0",
+				"FLUX_JOB_SIZE":   "4",
+				"FLUX_JOB_NNODES": "1",
 			},
 			want: JobContext{
 				JobID:    "cpuonly",

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -39,10 +39,10 @@ const (
 	MetricMemoryUsedPercent MetricType = "memory_used_percent"
 	MetricTemperature       MetricType = "temperature"
 	MetricPowerDraw         MetricType = "power_draw"
-	MetricPCIeTxKBps   MetricType = "pcie_tx_kbps"
-	MetricPCIeRxKBps   MetricType = "pcie_rx_kbps"
-	MetricNVLinkTxMBps MetricType = "nvlink_tx_mbps"
-	MetricNVLinkRxMBps MetricType = "nvlink_rx_mbps"
+	MetricPCIeTxKBps        MetricType = "pcie_tx_kbps"
+	MetricPCIeRxKBps        MetricType = "pcie_rx_kbps"
+	MetricNVLinkTxMBps      MetricType = "nvlink_tx_mbps"
+	MetricNVLinkRxMBps      MetricType = "nvlink_rx_mbps"
 )
 
 // Built-in profiles for common AI/ML workloads.

--- a/pkg/slurm/slurm_test.go
+++ b/pkg/slurm/slurm_test.go
@@ -145,7 +145,7 @@ func TestFromEnv(t *testing.T) {
 		{
 			name: "GPU_DEVICE_ORDINAL fallback",
 			env: map[string]string{
-				"SLURM_JOB_ID":      "555",
+				"SLURM_JOB_ID":       "555",
 				"GPU_DEVICE_ORDINAL": "3",
 			},
 			want: JobContext{
@@ -243,8 +243,8 @@ func TestSlurmGPUPriority(t *testing.T) {
 			env: map[string]string{
 				"SLURM_STEP_GPUS":      "0",
 				"SLURM_JOB_GPUS":       "0,1",
-				"GPU_DEVICE_ORDINAL":    "0,1,2",
-				"CUDA_VISIBLE_DEVICES":  "0,1,2,3",
+				"GPU_DEVICE_ORDINAL":   "0,1,2",
+				"CUDA_VISIBLE_DEVICES": "0,1,2,3",
 			},
 			want: "0",
 		},
@@ -252,16 +252,16 @@ func TestSlurmGPUPriority(t *testing.T) {
 			name: "job wins when no step",
 			env: map[string]string{
 				"SLURM_JOB_GPUS":       "0,1",
-				"GPU_DEVICE_ORDINAL":    "0,1,2",
-				"CUDA_VISIBLE_DEVICES":  "0,1,2,3",
+				"GPU_DEVICE_ORDINAL":   "0,1,2",
+				"CUDA_VISIBLE_DEVICES": "0,1,2,3",
 			},
 			want: "0,1",
 		},
 		{
 			name: "ordinal wins when no step or job",
 			env: map[string]string{
-				"GPU_DEVICE_ORDINAL":    "0,1,2",
-				"CUDA_VISIBLE_DEVICES":  "0,1,2,3",
+				"GPU_DEVICE_ORDINAL":   "0,1,2",
+				"CUDA_VISIBLE_DEVICES": "0,1,2,3",
 			},
 			want: "0,1,2",
 		},


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] CI/Build

## Description

Adds two Makefile targets:
- `make fmt` — `go fmt ./...`
- `make check-fmt` — fails (non-zero exit) listing any files that need gofmt,without modifying them

Wires `make check-fmt` into the CI `lint` job so PRs with unformatted Go are caught early.

Also applies gofmt across the existing tree (field alignment and import ordering in `cmd/` and a couple of tests, plus the `MetricType` const block) so the new `check-fmt` gate passes on `main` from the first run.

## Related Issue

Closes #63

## Checklist

- [ ] Tests added/updated <!-- N/A: build tooling + formatting only -->
- [ ] Documentation updated (if applicable) <!-- N/A -->
- [x] `make test` passes
- [x] `make lint` passes <!-- not run locally; CI lint job will verify -->
- [x] Commits are signed off (`git commit -s`)
