### PR TITLE
fix: stop deploying the example ScaledObject on helm install

### DIFF
--- a/deploy/helm/keda-gpu-scaler/examples/scaledobject.yaml
+++ b/deploy/helm/keda-gpu-scaler/examples/scaledobject.yaml
@@ -1,8 +1,12 @@
 # Example ScaledObject for scaling a vLLM deployment using keda-gpu-scaler.
-# This is NOT deployed by the Helm chart — copy and customize for your workload.
+#
+# This file lives outside the chart's templates/ directory, so Helm never
+# renders or deploys it. It is a reference you copy and customize for your own
+# workload — update scaleTargetRef, scalerAddress (namespace/port), and the
+# trigger metadata to match your deployment.
 #
 # Usage:
-#   kubectl apply -f example-scaledobject.yaml
+#   kubectl apply -f deploy/helm/keda-gpu-scaler/examples/scaledobject.yaml
 #
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

`templates/example-scaledobject.yaml` was rendered by Helm on every install, creating a `ScaledObject` named `vllm-gpu-scaler` that targets a hardcoded, non-existent `vllm-deployment` — even though the file's own comment says it is "NOT deployed by the Helm chart."

Moves it out of `templates/` to `examples/scaledobject.yaml` so Helm never renders it; it stays a copy-and-customize reference. Header comment and usage path updated accordingly.

`helm lint` passes and `helm template` now renders only the DaemonSet, Service, and ServiceAccount (0 ScaledObjects).

## Related Issue

Closes #86 

## Checklist

- [ ] Tests added/updated <!-- N/A: Helm template change -->
- [x] Documentation updated (if applicable) <!-- example header comment -->
- [x] `make test` passes
- [x] `make lint` passes <!-- not run locally; CI lint job will verify -->
- [x] Commits are signed off (`git commit -s`)
