### PR TITLE
fix: validate metricType in parseMetadata

### DIFF
--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -45,6 +45,35 @@ const (
 	MetricNVLinkRxMBps MetricType = "nvlink_rx_mbps"
 )
 
+// AllMetricTypes returns every supported MetricType, in a stable order suitable
+// for inclusion in user-facing error messages.
+func AllMetricTypes() []MetricType {
+	return []MetricType{
+		MetricGPUUtilization,
+		MetricMemoryUtilization,
+		MetricMemoryUsedMiB,
+		MetricMemoryUsedPercent,
+		MetricTemperature,
+		MetricPowerDraw,
+		MetricPCIeTxKBps,
+		MetricPCIeRxKBps,
+		MetricNVLinkTxMBps,
+		MetricNVLinkRxMBps,
+	}
+}
+
+// ValidMetricType reports whether t is a recognized MetricType.
+func ValidMetricType(t MetricType) bool {
+	switch t {
+	case MetricGPUUtilization, MetricMemoryUtilization, MetricMemoryUsedMiB,
+		MetricMemoryUsedPercent, MetricTemperature, MetricPowerDraw,
+		MetricPCIeTxKBps, MetricPCIeRxKBps, MetricNVLinkTxMBps, MetricNVLinkRxMBps:
+		return true
+	default:
+		return false
+	}
+}
+
 // Built-in profiles for common AI/ML workloads.
 var builtinProfiles = map[string]Profile{
 	"distributed-training": {

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -122,6 +122,26 @@ func TestList(t *testing.T) {
 	}
 }
 
+func TestValidMetricType(t *testing.T) {
+	// Every type returned by AllMetricTypes must be considered valid.
+	all := AllMetricTypes()
+	if len(all) == 0 {
+		t.Fatal("AllMetricTypes() returned no types")
+	}
+	for _, mt := range all {
+		if !ValidMetricType(mt) {
+			t.Errorf("ValidMetricType(%q) = false, want true", mt)
+		}
+	}
+
+	invalid := []MetricType{"", "gpu_utilzation", "GPU_UTILIZATION", "unknown"}
+	for _, mt := range invalid {
+		if ValidMetricType(mt) {
+			t.Errorf("ValidMetricType(%q) = true, want false", mt)
+		}
+	}
+}
+
 func TestProfileActivationValues(t *testing.T) {
 	// training profile should have 0 activation (no scale-to-zero)
 	training, _ := Get("training")

--- a/pkg/scaler/server.go
+++ b/pkg/scaler/server.go
@@ -160,7 +160,11 @@ func parseMetadata(metadata map[string]string) (scalerConfig, error) {
 		cfg.metricName = v
 	}
 	if v, ok := metadata["metricType"]; ok {
-		cfg.metricType = profiles.MetricType(v)
+		mt := profiles.MetricType(v)
+		if !profiles.ValidMetricType(mt) {
+			return cfg, fmt.Errorf("invalid metricType %q: must be one of %v", v, profiles.AllMetricTypes())
+		}
+		cfg.metricType = mt
 	}
 	if v, ok := metadata["targetValue"]; ok {
 		f, err := strconv.ParseFloat(v, 64)

--- a/pkg/scaler/server_test.go
+++ b/pkg/scaler/server_test.go
@@ -170,6 +170,28 @@ func TestParseMetadata(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid metricType typo",
+			metadata: map[string]string{
+				"metricType": "gpu_utilzation",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid non-default metricType",
+			metadata: map[string]string{
+				"metricType": "temperature",
+			},
+			want: scalerConfig{
+				metricName:          "keda_gpu_metric",
+				metricType:          profiles.MetricTemperature,
+				targetValue:         80,
+				activationThreshold: 0,
+				gpuIndex:            -1,
+				aggregation:         "max",
+				pollIntervalSeconds: 10,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

A typo'd `metricType` (e.g. `gpu_utilzation`) was silently accepted: `parseMetadata` cast any string to `MetricType`, and `extractMetric` then fell through to its `default` case returning GPU utilization — so the scaler scaled on the wrong metric with no error or warning.

This validates `metricType` against the known `MetricType` constants — mirroring how `aggregation` is already validated in the same function — and returns an error listing the valid values when it doesn't match.

- Adds `profiles.AllMetricTypes()` and `profiles.ValidMetricType()` so the set of valid types stays colocated with the constant definitions.
- Adds tests: invalid (typo) `metricType` is rejected, a valid non-default type is accepted, plus direct coverage of `ValidMetricType`/`AllMetricTypes`.

## Related Issue

Fixes #66

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable) <!-- N/A -->
- [x] `make test` passes
- [x] `make lint` passes <!-- not run locally; CI lint job will verify -->
- [x] Commits are signed off (`git commit -s`)
