### PR TITLE
feat: add --dry-run flag to gpu-metrics

### DIFF
--- a/cmd/gpu-metrics/main.go
+++ b/cmd/gpu-metrics/main.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -116,27 +117,32 @@ func main() {
 
 // printDryRun reports the resolved collection plan without initializing NVML.
 func printDryRun(w io.Writer, envCtx env.Context, format string, device int, interval time.Duration) {
-	fmt.Fprintln(w, "Dry run: showing the resolved configuration; NVML will not be initialized.")
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Environment   : %s\n", envCtx.Orchestrator)
+	lines := []string{
+		"Dry run: showing the resolved configuration; NVML will not be initialized.",
+		"",
+		fmt.Sprintf("Environment   : %s", envCtx.Orchestrator),
+	}
 	if envCtx.NodeName != "" {
-		fmt.Fprintf(w, "Node          : %s\n", envCtx.NodeName)
+		lines = append(lines, fmt.Sprintf("Node          : %s", envCtx.NodeName))
 	}
 	if envCtx.JobID != "" {
-		fmt.Fprintf(w, "Job / Rank    : %s / %d\n", envCtx.JobID, envCtx.TaskRank)
+		lines = append(lines, fmt.Sprintf("Job / Rank    : %s / %d", envCtx.JobID, envCtx.TaskRank))
 	}
 	if envCtx.PodName != "" {
-		fmt.Fprintf(w, "Pod           : %s\n", envCtx.PodName)
+		lines = append(lines, fmt.Sprintf("Pod           : %s", envCtx.PodName))
 	}
 	if envCtx.Namespace != "" {
-		fmt.Fprintf(w, "Namespace     : %s\n", envCtx.Namespace)
+		lines = append(lines, fmt.Sprintf("Namespace     : %s", envCtx.Namespace))
 	}
 	if envCtx.Partition != "" {
-		fmt.Fprintf(w, "Partition     : %s\n", envCtx.Partition)
+		lines = append(lines, fmt.Sprintf("Partition     : %s", envCtx.Partition))
 	}
-	fmt.Fprintf(w, "Output format : %s\n", describeFormat(format))
-	fmt.Fprintf(w, "Device filter : %s\n", describeDeviceFilter(device, envCtx.VisibleDevices()))
-	fmt.Fprintf(w, "Interval      : %s\n", describeInterval(interval))
+	lines = append(lines,
+		fmt.Sprintf("Output format : %s", describeFormat(format)),
+		fmt.Sprintf("Device filter : %s", describeDeviceFilter(device, envCtx.VisibleDevices())),
+		fmt.Sprintf("Interval      : %s", describeInterval(interval)),
+	)
+	_, _ = fmt.Fprintln(w, strings.Join(lines, "\n"))
 }
 
 // describeFormat returns the output format, flagging unrecognized values that

--- a/cmd/gpu-metrics/main.go
+++ b/cmd/gpu-metrics/main.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strconv"
@@ -34,11 +35,12 @@ import (
 )
 
 var (
-	format  = flag.String("format", "table", "Output format: table, json, csv")
+	format   = flag.String("format", "table", "Output format: table, json, csv")
 	interval = flag.Duration("interval", 0, "Collection interval (0 = one-shot)")
-	device  = flag.Int("device", -1, "GPU device index (-1 = all)")
-	quiet   = flag.Bool("quiet", false, "Suppress log output")
-	envFlag = flag.String("env", "auto", "Environment: auto, k8s, slurm, flux, standalone")
+	device   = flag.Int("device", -1, "GPU device index (-1 = all)")
+	quiet    = flag.Bool("quiet", false, "Suppress log output")
+	envFlag  = flag.String("env", "auto", "Environment: auto, k8s, slurm, flux, standalone")
+	dryRun   = flag.Bool("dry-run", false, "Print the resolved config and exit without initializing NVML")
 )
 
 func main() {
@@ -54,6 +56,13 @@ func main() {
 	// Resolve environment context once at startup.
 	envType := env.Parse(*envFlag)
 	envCtx := env.FromType(envType)
+
+	// --dry-run: report the resolved collection plan and exit before touching
+	// NVML, so users can verify their config on machines without a GPU/driver.
+	if *dryRun {
+		printDryRun(os.Stdout, envCtx, *format, *device, *interval)
+		return
+	}
 
 	if !*quiet {
 		logger.Info("Environment detected",
@@ -103,6 +112,62 @@ func main() {
 		case <-ticker.C:
 		}
 	}
+}
+
+// printDryRun reports the resolved collection plan without initializing NVML.
+func printDryRun(w io.Writer, envCtx env.Context, format string, device int, interval time.Duration) {
+	fmt.Fprintln(w, "Dry run: showing the resolved configuration; NVML will not be initialized.")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Environment   : %s\n", envCtx.Orchestrator)
+	if envCtx.NodeName != "" {
+		fmt.Fprintf(w, "Node          : %s\n", envCtx.NodeName)
+	}
+	if envCtx.JobID != "" {
+		fmt.Fprintf(w, "Job / Rank    : %s / %d\n", envCtx.JobID, envCtx.TaskRank)
+	}
+	if envCtx.PodName != "" {
+		fmt.Fprintf(w, "Pod           : %s\n", envCtx.PodName)
+	}
+	if envCtx.Namespace != "" {
+		fmt.Fprintf(w, "Namespace     : %s\n", envCtx.Namespace)
+	}
+	if envCtx.Partition != "" {
+		fmt.Fprintf(w, "Partition     : %s\n", envCtx.Partition)
+	}
+	fmt.Fprintf(w, "Output format : %s\n", describeFormat(format))
+	fmt.Fprintf(w, "Device filter : %s\n", describeDeviceFilter(device, envCtx.VisibleDevices()))
+	fmt.Fprintf(w, "Interval      : %s\n", describeInterval(interval))
+}
+
+// describeFormat returns the output format, flagging unrecognized values that
+// would silently fall back to the table renderer (see output()).
+func describeFormat(format string) string {
+	switch format {
+	case "table", "json", "csv":
+		return format
+	default:
+		return fmt.Sprintf("%q (unrecognized — will fall back to table)", format)
+	}
+}
+
+// describeDeviceFilter mirrors collect()'s selection precedence:
+// --device flag > scheduler-assigned GPUs > all GPUs.
+func describeDeviceFilter(device int, visible []int) string {
+	if device >= 0 {
+		return fmt.Sprintf("device %d (from --device)", device)
+	}
+	if len(visible) > 0 {
+		return fmt.Sprintf("scheduler-assigned devices %v", visible)
+	}
+	return "all GPUs"
+}
+
+// describeInterval renders the collection cadence.
+func describeInterval(d time.Duration) string {
+	if d <= 0 {
+		return "one-shot (single collection)"
+	}
+	return fmt.Sprintf("every %s (continuous)", d)
 }
 
 // collect gathers metrics for the appropriate set of GPUs.

--- a/cmd/gpu-metrics/main_test.go
+++ b/cmd/gpu-metrics/main_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The keda-gpu-scaler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pmady/keda-gpu-scaler/pkg/env"
+)
+
+func TestDescribeDeviceFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		device  int
+		visible []int
+		want    string
+	}{
+		{"explicit device flag", 2, nil, "device 2 (from --device)"},
+		{"device flag wins over scheduler assignment", 0, []int{3, 4}, "device 0 (from --device)"},
+		{"scheduler-assigned devices", -1, []int{1, 2}, "scheduler-assigned devices [1 2]"},
+		{"all gpus", -1, nil, "all GPUs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := describeDeviceFilter(tt.device, tt.visible); got != tt.want {
+				t.Errorf("describeDeviceFilter(%d, %v) = %q, want %q", tt.device, tt.visible, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDescribeInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{"zero is one-shot", 0, "one-shot (single collection)"},
+		{"negative is one-shot", -5 * time.Second, "one-shot (single collection)"},
+		{"positive is continuous", 2 * time.Second, "every 2s (continuous)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := describeInterval(tt.in); got != tt.want {
+				t.Errorf("describeInterval(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDescribeFormat(t *testing.T) {
+	for _, f := range []string{"table", "json", "csv"} {
+		if got := describeFormat(f); got != f {
+			t.Errorf("describeFormat(%q) = %q, want it unchanged", f, got)
+		}
+	}
+	if got := describeFormat("xml"); !strings.Contains(got, "unrecognized") {
+		t.Errorf("describeFormat(\"xml\") = %q, want it to flag the value as unrecognized", got)
+	}
+}
+
+// The issue requires the dry-run output to report the detected environment,
+// output format, device filter, and interval setting.
+func TestPrintDryRunReportsRequiredItems(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := env.Context{Orchestrator: "standalone", NodeName: "dev-box"}
+	printDryRun(&buf, ctx, "json", -1, 0)
+	out := buf.String()
+
+	for _, want := range []string{
+		"standalone",                   // detected environment
+		"dev-box",                      // node context
+		"json",                         // output format
+		"all GPUs",                     // device filter
+		"one-shot (single collection)", // interval setting
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// Scheduler-specific context (k8s pod/namespace, slurm partition) should appear
+// in the dry-run report, mirroring the table banner.
+func TestPrintDryRunRendersSchedulerContext(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := env.Context{
+		Orchestrator: "k8s",
+		NodeName:     "node-1",
+		JobID:        "job-7",
+		TaskRank:     2,
+		PodName:      "scaler-abc",
+		Namespace:    "keda",
+		Partition:    "gpu-debug",
+	}
+	printDryRun(&buf, ctx, "table", -1, 0)
+	out := buf.String()
+
+	for _, want := range []string{"node-1", "job-7", "scaler-abc", "keda", "gpu-debug"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

Adds a `--dry-run` flag to the `gpu-metrics` CLI that prints the resolved collection plan and exits **before** initializing NVML — so you can verify your config on a machine without a GPU/driver (where NVML init would otherwise fail).

It reports:
- **Detected environment** (`k8s` / `slurm` / `flux` / `standalone`), plus node, job/rank, pod, namespace, and partition context when those are set
- **Output format** (and flags an unrecognized value that would fall back to the table renderer)
- **Device filter**, mirroring `collect()`'s precedence: `--device` > scheduler-assigned GPUs > all GPUs
- **Interval** (one-shot vs. continuous)

**Example:**
```
$ gpu-metrics --dry-run --env k8s --format json
Dry run: showing the resolved configuration; NVML will not be initialized.

Environment   : k8s
Node          : node-1
Pod           : scaler-abc
Namespace     : keda
Output format : json
Device filter : all GPUs
Interval      : one-shot (single collection)
```
Verified on a GPU-less machine: 
`--dry-run` exits 0, while a plain run fails with `nvml init failed: ERROR_LIBRARY_NOT_FOUND` — confirming the dry-run path returns before `gpu.NewCollector`.

## Related Issue

Closes #71

## Checklist

- [x] Tests added/updated <!-- cmd/gpu-metrics/main_test.go -->
- [ ] Documentation updated (if applicable) <!-- N/A: flag is self-documenting via --help -->
- [x] `make test` passes
- [x] `make lint` passes <!-- not run locally; CI lint job will verify -->
- [x] Commits are signed off (`git commit -s`)
