### PR TITLE
update: switch to maintained TekWizely/pre-commit-golang fork

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,8 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
+  - repo: https://github.com/TekWizely/pre-commit-golang
+    rev: v1.0.0-rc.4
     hooks:
       - id: go-fmt
       # golangci-lint is intentionally on the `manual` stage: it is accurate but


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactoring
- [ ] CI/Build

## Description

<!-- Describe your changes -->
dnephin/pre-commit-golang is archived. Point the go-fmt and golangci-lint hooks at the actively maintained TekWizely/pre-commit-golang fork (v1.0.0-rc.4). The hook IDs (go-fmt, golangci-lint) are unchanged, so the config behaves the same; verified that pre-commit validates the config and the go-fmt hook resolves and runs against the new repo.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [x] `make test` passes
- [x] `make lint` passes
- [x] Commits are signed off (`git commit -s`)
