### PR TITLE
ci: report test coverage in CI and PR summary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,25 @@ jobs:
         run: CGO_ENABLED=1 go build -v ./cmd/keda-gpu-scaler/
 
       - name: Test
-        run: go test -v -race ./pkg/...
+        run: go test -v -race -covermode=atomic -coverprofile=coverage.out ./...
+
+      - name: Report coverage
+        if: matrix.arch == 'amd64'
+        run: |
+          go tool cover -func=coverage.out
+          total=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}')
+          echo "Total coverage: ${total}"
+          {
+            echo "### Test coverage: ${total}"
+            echo ""
+            echo "<details><summary>Per-function coverage</summary>"
+            echo ""
+            echo '```'
+            go tool cover -func=coverage.out
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Vet
         run: go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ proto: ## Generate protobuf Go code
 		--go-grpc_out=pkg/externalscaler --go-grpc_opt=paths=source_relative \
 		-Iproto externalscaler.proto
 
-test: ## Run unit tests
-	go test -v -race ./pkg/...
+test: ## Run unit tests (pkg + cmd; e2e is build-tagged out, run via test-e2e)
+	go test -v -race ./...
 
 test-e2e: ## Run e2e integration tests (no GPU required — uses mock collector)
 	go test -v -tags=e2e -race ./tests/e2e/...


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] CI/Build

## Description

Consolidates two related CI improvements:

1. **Broaden the test scope** from `./pkg/...` to `./...` in both the Makefile `test` target and the CI build job, so `cmd/` package tests run too (the e2e suite stays separate — it's build-tagged and run via `make test-e2e`).

2. **Report coverage**, folded into the build job's existing race-test step: `go test -v -race -covermode=atomic -coverprofile=coverage.out ./...`. A guarded `Report coverage` step (`if: matrix.arch == 'amd64'`, so the summary isn't emitted twice across the amd64/arm64 build matrix) prints per-function coverage and the total to the CI log, and writes them to the GitHub step summary so coverage shows in the PR's **Checks** tab.

No external service, secrets, or third-party actions — consistent with the repo's SHA-pinned, least-privilege CI. `coverage.out` is already ignored via `.gitignore` (`*.out`).

## Related Issue

Closes #74

## Checklist

- [ ] Tests added/updated <!-- N/A: CI/build + Makefile change -->
- [ ] Documentation updated (if applicable)
- [x] `make test` passes
- [x] `make lint` passes <!-- no Go code changed; golangci-lint baseline is 0 issues -->
- [x] Commits are signed off (`git commit -s`)
