### PR TITLE
feat: log gpu_name with per-GPU metric values

### DIFF
--- a/pkg/scaler/server.go
+++ b/pkg/scaler/server.go
@@ -228,7 +228,9 @@ func (s *GPUExternalScaler) getMetricValue(cfg scalerConfig) (float64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return extractMetric(m, cfg.metricType), nil
+		value := extractMetric(m, cfg.metricType)
+		s.logMetric(m, cfg.metricType, value)
+		return value, nil
 	}
 
 	allMetrics, err := s.collector.CollectAll()
@@ -242,9 +244,22 @@ func (s *GPUExternalScaler) getMetricValue(cfg scalerConfig) (float64, error) {
 	values := make([]float64, len(allMetrics))
 	for i, m := range allMetrics {
 		values[i] = extractMetric(m, cfg.metricType)
+		s.logMetric(m, cfg.metricType, values[i])
 	}
 
 	return aggregate(values, cfg.aggregation), nil
+}
+
+// logMetric emits a per-GPU debug log line that includes the GPU name, so that
+// on clusters with mixed GPU types (e.g. A100 + H100) operators can tell which
+// card a metric value came from rather than only seeing the index.
+func (s *GPUExternalScaler) logMetric(m gpu.Metrics, metricType profiles.MetricType, value float64) {
+	s.logger.Debug("collected GPU metric",
+		zap.Int("gpu_index", m.Index),
+		zap.String("gpu_name", m.Name),
+		zap.String("metric_type", string(metricType)),
+		zap.Float64("value", value),
+	)
 }
 
 func extractMetric(m gpu.Metrics, metricType profiles.MetricType) float64 {

--- a/pkg/scaler/server_test.go
+++ b/pkg/scaler/server_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	pb "github.com/pmady/keda-gpu-scaler/pkg/externalscaler"
 	"github.com/pmady/keda-gpu-scaler/pkg/gpu"
@@ -691,5 +692,48 @@ func TestIsActiveInvalidMetadata(t *testing.T) {
 	})
 	if err == nil {
 		t.Error("IsActive() with invalid profile should return error")
+	}
+}
+
+// Per-GPU metric logs must carry the GPU name (issue #75) so operators on
+// mixed-GPU clusters can tell which card a value came from.
+func TestGetMetricValueLogsGPUName(t *testing.T) {
+	tests := []struct {
+		name      string
+		metadata  map[string]string
+		wantLines int
+	}{
+		{"all GPUs", map[string]string{}, len(testDevices)},
+		{"single GPU", map[string]string{"gpuIndex": "0"}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zap.DebugLevel)
+			s := NewGPUExternalScaler(gpu.NewMockCollector(testDevices), zap.New(core))
+
+			if _, err := s.GetMetrics(context.Background(), &pb.GetMetricsRequest{
+				ScaledObjectRef: &pb.ScaledObjectRef{Name: "test-so", ScalerMetadata: tt.metadata},
+			}); err != nil {
+				t.Fatalf("GetMetrics() error = %v", err)
+			}
+
+			entries := logs.FilterMessage("collected GPU metric").All()
+			if len(entries) != tt.wantLines {
+				t.Fatalf("got %d per-GPU log lines, want %d", len(entries), tt.wantLines)
+			}
+			for _, e := range entries {
+				fields := e.ContextMap()
+				if _, ok := fields["gpu_index"]; !ok {
+					t.Errorf("log entry missing gpu_index field: %v", fields)
+				}
+				name, ok := fields["gpu_name"]
+				if !ok {
+					t.Errorf("log entry missing gpu_name field: %v", fields)
+				} else if name != "A100" {
+					t.Errorf("gpu_name = %v, want A100", name)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

On clusters with mixed GPU types (e.g. A100 + H100), the scaler's logs gave no way to tell which card a metric value came from. This adds a per-GPU **debug** log line in `getMetricValue` (both the single-device and aggregate paths), emitted via a small `logMetric` helper, with:

- `gpu_index`
- `gpu_name`
- `metric_type`
- `value`

Note: the scaler previously computed per-GPU values silently — there were no existing log lines to simply add `gpu_name` to — so this introduces the logging. It's gated at **debug** level, so the default (`info`) output is unchanged and there's no added noise in production; operators flip `--log-level=debug` to see per-card values.

## Related Issue

Closes #75

## Checklist

- [x] Tests added/updated <!-- observer-based test asserts gpu_name on every per-GPU log line, both paths -->
- [ ] Documentation updated (if applicable)
- [x] `make test` passes
- [x] `make lint` passes <!-- golangci-lint: 0 issues -->
- [x] Commits are signed off (`git commit -s`)
