### PR TITLE
feat: publish Helm chart to GHCR via OCI and add chart test (#9)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,3 +109,37 @@ jobs:
             --generate-notes \
             keda-gpu-scaler_*_linux_*.tar.gz \
             checksums.txt
+
+  # Package the Helm chart and publish it as an OCI artifact to GHCR on tag push.
+  # Chart and app versions are stamped from the release tag (vX.Y.Z -> X.Y.Z), so
+  # the published chart version tracks the release rather than Chart.yaml's
+  # in-repo development version.
+  chart:
+    runs-on: ubuntu-latest
+    needs: [images]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+
+      - name: Package chart
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          helm package deploy/helm/keda-gpu-scaler \
+            --version "${version}" --app-version "${version}"
+
+      - name: Log in to GHCR
+        env:
+          HELM_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${HELM_REGISTRY_TOKEN}" | helm registry login ghcr.io \
+            --username "${{ github.actor }}" --password-stdin
+
+      - name: Push chart to GHCR (OCI)
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          helm push "keda-gpu-scaler-${version}.tgz" oci://ghcr.io/pmady/charts

--- a/README.md
+++ b/README.md
@@ -92,13 +92,27 @@ kubectl apply -f deploy/manifests.yaml
 
 This deploys a DaemonSet that runs on every GPU node in your cluster, plus a ClusterIP Service for KEDA to discover it.
 
-Or use Helm:
+Or use Helm.
+
+**From the published OCI chart** (recommended — replace `<X.Y.Z>` with the
+[latest release](https://github.com/pmady/keda-gpu-scaler/releases)):
+
+```bash
+helm install keda-gpu-scaler \
+  oci://ghcr.io/pmady/charts/keda-gpu-scaler --version <X.Y.Z> \
+  --namespace keda --create-namespace
+```
+
+**From a local checkout:**
 
 ```bash
 helm install keda-gpu-scaler deploy/helm/keda-gpu-scaler \
   --namespace keda \
   --set nodeSelector."nvidia\.com/gpu\.present"=true
 ```
+
+See the [chart README](deploy/helm/keda-gpu-scaler/README.md) for all
+configurable values.
 
 ### 2. Attach to your AI Workload
 

--- a/deploy/helm/keda-gpu-scaler/templates/tests/test-connection.yaml
+++ b/deploy/helm/keda-gpu-scaler/templates/tests/test-connection.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "keda-gpu-scaler.fullname" . }}-test-connection"
+  labels:
+    {{- include "keda-gpu-scaler.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: grpc-connection
+      image: busybox:1.37
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -eu
+          host="{{ include "keda-gpu-scaler.fullname" . }}"
+          port="{{ .Values.grpc.port }}"
+          echo "Checking the keda-gpu-scaler gRPC endpoint at ${host}:${port} ..."
+          nc -w 5 "${host}" "${port}" < /dev/null
+          echo "OK: gRPC port ${port} on ${host} is reachable."


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] CI/Build

## Description

Completes the remaining parts of the Helm chart epic (#9). `values.yaml` (all configurable fields) and `NOTES.txt` were already in place, so the remaining work was:

- **Chart test** — `templates/tests/test-connection.yaml`, a `helm test` Pod that TCP-smoke-tests the gRPC endpoint (busybox `nc`), honoring `grpc.port`.
- **Publishing** — a new `chart` job in the release workflow that, on a `v*` tag, packages the chart and `helm push`es it as an **OCI artifact** to `oci://ghcr.io/pmady/charts`. Chart and app versions are **stamped from the tag** (`vX.Y.Z → X.Y.Z`), since `Chart.yaml` carries the in-repo dev version. `needs: [images]` so the chart only publishes after its image; SHA-pinned actions; `packages: write` scoped to the job.
- **README** — documents the published-chart install path (`helm install oci://ghcr.io/pmady/charts/keda-gpu-scaler --version <X.Y.Z>`).
- **CONTRIBUTING** — documents the release-time chart publishing and the one-time owner setup.

No new secrets are required — publishing reuses `GITHUB_TOKEN` with `packages: write`, the same as the Docker image push.

## Related Issue

Closes #9

## Reviewer / owner notes (one-time, after the first chart release)

1. Make the GHCR package `charts/keda-gpu-scaler` **public** (same as the image).
2. List the OCI repo `oci://ghcr.io/pmady/charts` on Artifact Hub (`artifacthub-repo.yml` already provides ownership verification).

## Checklist

- [ ] Tests added/updated <!-- Helm chart test added; no Go change -->
- [x] Documentation updated (README + CONTRIBUTING)
- [x] `make test` passes
- [x] `make lint` passes <!-- no Go changed; helm lint + make helm-test pass -->
- [x] Commits are signed off (`git commit -s`)
