### PR TITLE
feat: add --version flag to keda-gpu-scaler and gpu-metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,22 @@
 BINARY_NAME := keda-gpu-scaler
 IMAGE_REPO := ghcr.io/pmady/keda-gpu-scaler
 IMAGE_TAG ?= latest
-VERSION ?= v0.1.0
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+BUILD_DATE ?= $(shell date -u +%Y-%m-%d)
 GOPATH := $(shell go env GOPATH)
+
+# Inject version metadata into the binaries at link time (see pkg/version).
+VERSION_PKG := github.com/pmady/keda-gpu-scaler/pkg/version
+LDFLAGS := -X $(VERSION_PKG).Version=$(VERSION) -X $(VERSION_PKG).BuildDate=$(BUILD_DATE)
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 build: ## Build the KEDA scaler binary (requires CGO for NVML)
-	CGO_ENABLED=1 go build -o bin/$(BINARY_NAME) ./cmd/keda-gpu-scaler/
+	CGO_ENABLED=1 go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY_NAME) ./cmd/keda-gpu-scaler/
 
 build-metrics: ## Build the standalone GPU metrics CLI
-	CGO_ENABLED=1 go build -o bin/gpu-metrics ./cmd/gpu-metrics/
+	CGO_ENABLED=1 go build -ldflags "$(LDFLAGS)" -o bin/gpu-metrics ./cmd/gpu-metrics/
 
 build-all: build build-metrics ## Build all binaries
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,20 @@ make docker-release VERSION=v0.1.0
 make deploy
 ```
 
+### Checking the Version
+
+Both binaries accept a `--version` flag (and a bare `version` argument) that
+prints the version, Go version, and build date, then exits. Unlike normal
+operation, this does **not** require a GPU or the NVIDIA driver:
+
+```bash
+keda-gpu-scaler --version    # keda-gpu-scaler v0.5.0 (go1.26.4, built 2026-06-25)
+gpu-metrics --version        # gpu-metrics v0.5.0 (go1.26.4, built 2026-06-25)
+```
+
+`make build` stamps the version from `git describe` at link time; builds without
+ldflags (e.g. `go run`) report `dev`.
+
 ### Standalone GPU Metrics CLI
 
 Collect GPU metrics without Kubernetes — works on bare metal, SLURM jobs, Flux jobs, Kubernetes pods, and Singularity containers. The same binary and the same JSON schema work everywhere.
@@ -273,6 +287,7 @@ gpu-metrics --format csv          # CSV for analysis
 gpu-metrics --interval 5s         # continuous collection
 gpu-metrics --device 0 --quiet    # single GPU, no logs
 gpu-metrics --env slurm           # force environment (auto|k8s|slurm|flux|standalone)
+gpu-metrics --version             # print version and exit (no GPU/NVML required)
 ```
 
 The `--env` flag auto-detects the orchestrator by default. Detection priority: **SLURM → Flux → Kubernetes → standalone**.

--- a/cmd/gpu-metrics/main.go
+++ b/cmd/gpu-metrics/main.go
@@ -33,19 +33,26 @@ import (
 
 	"github.com/pmady/keda-gpu-scaler/pkg/env"
 	"github.com/pmady/keda-gpu-scaler/pkg/gpu"
+	"github.com/pmady/keda-gpu-scaler/pkg/version"
 )
 
 var (
-	format   = flag.String("format", "table", "Output format: table, json, csv")
-	interval = flag.Duration("interval", 0, "Collection interval (0 = one-shot)")
-	device   = flag.Int("device", -1, "GPU device index (-1 = all)")
-	quiet    = flag.Bool("quiet", false, "Suppress log output")
-	envFlag  = flag.String("env", "auto", "Environment: auto, k8s, slurm, flux, standalone")
-	dryRun   = flag.Bool("dry-run", false, "Print the resolved config and exit without initializing NVML")
+	format      = flag.String("format", "table", "Output format: table, json, csv")
+	interval    = flag.Duration("interval", 0, "Collection interval (0 = one-shot)")
+	device      = flag.Int("device", -1, "GPU device index (-1 = all)")
+	quiet       = flag.Bool("quiet", false, "Suppress log output")
+	envFlag     = flag.String("env", "auto", "Environment: auto, k8s, slurm, flux, standalone")
+	dryRun      = flag.Bool("dry-run", false, "Print the resolved config and exit without initializing NVML")
+	showVersion = flag.Bool("version", false, "Print version information and exit")
 )
 
 func main() {
 	flag.Parse()
+
+	if version.Requested(*showVersion, flag.Args()) {
+		fmt.Println(version.String("gpu-metrics"))
+		return
+	}
 
 	logger := zap.NewNop()
 	if !*quiet {

--- a/cmd/keda-gpu-scaler/main.go
+++ b/cmd/keda-gpu-scaler/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pmady/keda-gpu-scaler/pkg/metrics"
 	"github.com/pmady/keda-gpu-scaler/pkg/probes"
 	"github.com/pmady/keda-gpu-scaler/pkg/scaler"
+	"github.com/pmady/keda-gpu-scaler/pkg/version"
 )
 
 var (
@@ -47,10 +48,16 @@ var (
 	metricsPort = flag.Int("metrics-port", 9090, "Prometheus metrics HTTP port (0 to disable)")
 	probePort   = flag.Int("probe-port", 8081, "Health/readiness HTTP port (0 to disable)")
 	logLevel    = flag.String("log-level", "info", "Log level (debug, info, warn, error)")
+	showVersion = flag.Bool("version", false, "Print version information and exit")
 )
 
 func main() {
 	flag.Parse()
+
+	if version.Requested(*showVersion, flag.Args()) {
+		fmt.Println(version.String("keda-gpu-scaler"))
+		return
+	}
 
 	logger := initLogger(*logLevel)
 	defer func() { _ = logger.Sync() }()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The keda-gpu-scaler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version exposes build-time version metadata for the project's
+// binaries. Version and BuildDate are injected at link time via -ldflags -X
+// (see the Makefile); they keep their placeholder values for un-stamped builds
+// such as `go run` or `go build` without ldflags.
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// Version is the release version, injected at build time (e.g. "v0.5.0").
+	Version = "dev"
+	// BuildDate is the UTC build date, injected at build time (e.g. "2026-06-23").
+	BuildDate = "unknown"
+)
+
+// String returns a one-line version summary for the named binary, e.g.
+// "keda-gpu-scaler v0.5.0 (go1.26.4, built 2026-06-23)".
+func String(name string) string {
+	return fmt.Sprintf("%s %s (%s, built %s)", name, Version, runtime.Version(), BuildDate)
+}
+
+// Requested reports whether the user asked for version output, either via the
+// --version flag (flagSet) or a bare "version" argument as the first non-flag
+// argument. Pass flag.Args() for args.
+func Requested(flagSet bool, args []string) bool {
+	return flagSet || (len(args) > 0 && args[0] == "version")
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The keda-gpu-scaler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	got := String("keda-gpu-scaler")
+
+	// Must contain the binary name, version, Go version, and build date.
+	for _, want := range []string{"keda-gpu-scaler", Version, runtime.Version(), BuildDate} {
+		if !strings.Contains(got, want) {
+			t.Errorf("String() = %q, missing %q", got, want)
+		}
+	}
+
+	// Format: "<name> <version> (<goversion>, built <date>)".
+	wantPrefix := "keda-gpu-scaler " + Version + " (" + runtime.Version() + ", built " + BuildDate + ")"
+	if got != wantPrefix {
+		t.Errorf("String() = %q, want %q", got, wantPrefix)
+	}
+}
+
+func TestRequested(t *testing.T) {
+	tests := []struct {
+		name    string
+		flagSet bool
+		args    []string
+		want    bool
+	}{
+		{"--version flag set", true, nil, true},
+		{"--version flag set, args ignored", true, []string{"foo"}, true},
+		{"bare version argument", false, []string{"version"}, true},
+		{"bare version argument with extras", false, []string{"version", "--foo"}, true},
+		{"no flag, no args", false, nil, false},
+		{"no flag, empty args", false, []string{}, false},
+		{"version not the first argument", false, []string{"foo", "version"}, false},
+		{"unrelated argument", false, []string{"help"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Requested(tt.flagSet, tt.args); got != tt.want {
+				t.Errorf("Requested(%v, %v) = %v, want %v", tt.flagSet, tt.args, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

Adds a `--version` flag (and a bare `version` argument) to both binaries. It prints `<name> <version> (<goversion>, built <date>)` and exits before any other startup, e.g.:

keda-gpu-scaler v0.5.0 (go1.26.4, built 2026-06-24) gpu-metrics v0.5.0 (go1.26.4, built 2026-06-24)

- Version and build date are injected at link time via `-ldflags -X` into a new shared `pkg/version` package (kept shared so both binaries emit identical output and the format lives in one place).
- Whether version output was requested is decided by a small, pure `version.Requested(flagSet, args)` helper (`--version` flag or bare `version` arg), so the logic is unit-tested rather than buried in `main()`.
- The `Makefile` derives `VERSION` from `git describe --tags --always --dirty`, stamps the UTC build date, and passes both to the `build` / `build-metrics` targets. `VERSION` is still overridable (`make build VERSION=...`).
- Un-stamped builds (`go run`, or `go build` without ldflags) fall back to `dev` / `unknown` placeholders.

## Related Issue

Closes #62

## Notes for reviewers

- Slightly broader than the issue's literal 3-file list: I added a shared `pkg/version` package (2 files) rather than duplicating the version vars and format string in each `main`.
- `VERSION` in the Makefile previously defaulted to a stale hardcoded `v0.1.0`; it now derives from `git describe`, which also improves the existing `docker-release` target. Still overridable.
- **Out of scope here:** the Docker image and the `release.yaml` binary builds run `go build` without these ldflags (and `.dockerignore` excludes `.git`), so released artifacts currently report `dev`. Wiring version into the release/Docker builds (via a build ARG) can be a follow-up if desired.

## Checklist

- [x] Tests added/updated <!-- pkg/version: TestString + TestRequested, 100% coverage -->
- [x] Documentation updated (if applicable) <!-- README: --version documented -->
- [x] `make test` passes
- [x] `make lint` passes <!-- golangci-lint: 0 issues -->
- [x] Commits are signed off (`git commit -s`)