### PR TITLE
feat: add vLLM queue depth and KV cache usage scaling

### DIFF
--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -43,6 +43,10 @@ const (
 	MetricPCIeRxKBps        MetricType = "pcie_rx_kbps"
 	MetricNVLinkTxMBps      MetricType = "nvlink_tx_mbps"
 	MetricNVLinkRxMBps      MetricType = "nvlink_rx_mbps"
+
+	// vLLM engine metrics — scraped from the vLLM /metrics endpoint, not NVML.
+	MetricVLLMQueueDepth   MetricType = "vllm_queue_depth"
+	MetricVLLMKVCacheUsage MetricType = "vllm_kv_cache_usage"
 )
 
 // AllMetricTypes returns every supported MetricType, in a stable order suitable
@@ -59,7 +63,14 @@ func AllMetricTypes() []MetricType {
 		MetricPCIeRxKBps,
 		MetricNVLinkTxMBps,
 		MetricNVLinkRxMBps,
+		MetricVLLMQueueDepth,
+		MetricVLLMKVCacheUsage,
 	}
+}
+
+// IsVLLMMetric reports whether t requires the vLLM engine endpoint rather than NVML.
+func IsVLLMMetric(t MetricType) bool {
+	return t == MetricVLLMQueueDepth || t == MetricVLLMKVCacheUsage
 }
 
 // ValidMetricType reports whether t is a recognized MetricType.
@@ -67,7 +78,8 @@ func ValidMetricType(t MetricType) bool {
 	switch t {
 	case MetricGPUUtilization, MetricMemoryUtilization, MetricMemoryUsedMiB,
 		MetricMemoryUsedPercent, MetricTemperature, MetricPowerDraw,
-		MetricPCIeTxKBps, MetricPCIeRxKBps, MetricNVLinkTxMBps, MetricNVLinkRxMBps:
+		MetricPCIeTxKBps, MetricPCIeRxKBps, MetricNVLinkTxMBps, MetricNVLinkRxMBps,
+		MetricVLLMQueueDepth, MetricVLLMKVCacheUsage:
 		return true
 	default:
 		return false
@@ -97,6 +109,17 @@ var builtinProfiles = map[string]Profile{
 		CooldownSeconds:    60,
 		ScaleUpStabilize:   15,
 		ScaleDownStabilize: 120,
+	},
+	"vllm-queue-depth": {
+		Name:               "vllm-queue-depth",
+		MetricName:         "keda_gpu_vllm_queue_depth",
+		Description:        "vLLM queue depth — scale on pending inference requests",
+		TargetValue:        5,
+		ActivationValue:    1,
+		MetricType:         MetricVLLMQueueDepth,
+		CooldownSeconds:    30,
+		ScaleUpStabilize:   10,
+		ScaleDownStabilize: 60,
 	},
 	"triton-inference": {
 		Name:               "triton-inference",

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -98,12 +98,13 @@ func TestGetBuiltinProfiles(t *testing.T) {
 
 func TestList(t *testing.T) {
 	names := List()
-	if len(names) != 5 {
-		t.Errorf("List() returned %d profiles, want 5", len(names))
+	if len(names) != 6 {
+		t.Errorf("List() returned %d profiles, want 6", len(names))
 	}
 
 	expected := map[string]bool{
 		"vllm-inference":       false,
+		"vllm-queue-depth":     false,
 		"triton-inference":     false,
 		"training":             false,
 		"batch":                false,

--- a/pkg/scaler/server.go
+++ b/pkg/scaler/server.go
@@ -27,20 +27,23 @@ import (
 	pb "github.com/pmady/keda-gpu-scaler/pkg/externalscaler"
 	"github.com/pmady/keda-gpu-scaler/pkg/gpu"
 	"github.com/pmady/keda-gpu-scaler/pkg/profiles"
+	"github.com/pmady/keda-gpu-scaler/pkg/vllm"
 )
 
 // GPUExternalScaler implements the KEDA ExternalScaler gRPC interface.
 type GPUExternalScaler struct {
 	pb.UnimplementedExternalScalerServer
-	collector gpu.MetricsCollector
-	logger    *zap.Logger
+	collector   gpu.MetricsCollector
+	vllmClients map[string]*vllm.Client // keyed by endpoint URL
+	logger      *zap.Logger
 }
 
 // NewGPUExternalScaler creates a new GPU external scaler server.
 func NewGPUExternalScaler(collector gpu.MetricsCollector, logger *zap.Logger) *GPUExternalScaler {
 	return &GPUExternalScaler{
-		collector: collector,
-		logger:    logger,
+		collector:   collector,
+		vllmClients: make(map[string]*vllm.Client),
+		logger:      logger,
 	}
 }
 
@@ -132,6 +135,7 @@ type scalerConfig struct {
 	gpuIndex            int // -1 means aggregate all GPUs
 	aggregation         string
 	pollIntervalSeconds int
+	vllmEndpoint        string // e.g. "http://vllm-svc:8000/metrics"
 }
 
 func parseMetadata(metadata map[string]string) (scalerConfig, error) {
@@ -218,11 +222,35 @@ func parseMetadata(metadata map[string]string) (scalerConfig, error) {
 		}
 		cfg.pollIntervalSeconds = i
 	}
+	if v, ok := metadata["vllmEndpoint"]; ok {
+		cfg.vllmEndpoint = v
+	}
+
+	// vLLM metrics require the endpoint to be set.
+	if profiles.IsVLLMMetric(cfg.metricType) && cfg.vllmEndpoint == "" {
+		return cfg, fmt.Errorf("metricType %q requires vllmEndpoint to be set", cfg.metricType)
+	}
 
 	return cfg, nil
 }
 
+// getVLLMClient returns a cached vLLM client for the given endpoint, creating
+// one on first use.
+func (s *GPUExternalScaler) getVLLMClient(endpoint string) *vllm.Client {
+	if c, ok := s.vllmClients[endpoint]; ok {
+		return c
+	}
+	c := vllm.NewClient(endpoint, s.logger)
+	s.vllmClients[endpoint] = c
+	return c
+}
+
 func (s *GPUExternalScaler) getMetricValue(cfg scalerConfig) (float64, error) {
+	// vLLM metrics come from the engine HTTP endpoint, not NVML.
+	if profiles.IsVLLMMetric(cfg.metricType) {
+		return s.getVLLMMetricValue(cfg)
+	}
+
 	if cfg.gpuIndex >= 0 {
 		m, err := s.collector.CollectDevice(cfg.gpuIndex)
 		if err != nil {
@@ -260,6 +288,32 @@ func (s *GPUExternalScaler) logMetric(m gpu.Metrics, metricType profiles.MetricT
 		zap.String("metric_type", string(metricType)),
 		zap.Float64("value", value),
 	)
+}
+
+func (s *GPUExternalScaler) getVLLMMetricValue(cfg scalerConfig) (float64, error) {
+	c := s.getVLLMClient(cfg.vllmEndpoint)
+	m, err := c.Scrape()
+	if err != nil {
+		return 0, err
+	}
+
+	var value float64
+	switch cfg.metricType {
+	case profiles.MetricVLLMQueueDepth:
+		value = m.QueueDepth
+	case profiles.MetricVLLMKVCacheUsage:
+		value = m.KVCacheUsage * 100 // normalize 0-1 → 0-100 for KEDA target comparison
+	}
+
+	s.logger.Debug("scraped vLLM metric",
+		zap.String("endpoint", cfg.vllmEndpoint),
+		zap.String("metric_type", string(cfg.metricType)),
+		zap.Float64("value", value),
+		zap.Float64("queue_depth", m.QueueDepth),
+		zap.Float64("running", m.RunningCount),
+		zap.Float64("kv_cache", m.KVCacheUsage),
+	)
+	return value, nil
 }
 
 func extractMetric(m gpu.Metrics, metricType profiles.MetricType) float64 {

--- a/pkg/scaler/server_test.go
+++ b/pkg/scaler/server_test.go
@@ -18,6 +18,9 @@ package scaler
 
 import (
 	"context"
+	"math"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"go.uber.org/zap"
@@ -735,5 +738,158 @@ func TestGetMetricValueLogsGPUName(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// --- vLLM queue depth / KV cache tests ---
+
+const fakeVLLMMetrics = `# HELP vllm:num_requests_waiting Number of waiting requests
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{model_name="llama-7b"} 8
+# HELP vllm:num_requests_running Number of running requests
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{model_name="llama-7b"} 4
+# HELP vllm:gpu_cache_usage_perc KV cache usage
+# TYPE vllm:gpu_cache_usage_perc gauge
+vllm:gpu_cache_usage_perc 0.72
+# HELP vllm:num_requests_swapped swapped
+# TYPE vllm:num_requests_swapped gauge
+vllm:num_requests_swapped 0
+`
+
+func fakeVLLMServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fakeVLLMMetrics))
+	}))
+}
+
+func TestGetMetrics_VLLMQueueDepth(t *testing.T) {
+	ts := fakeVLLMServer()
+	defer ts.Close()
+
+	s := NewGPUExternalScaler(gpu.NewMockCollector(testDevices), zap.NewNop())
+	resp, err := s.GetMetrics(context.Background(), &pb.GetMetricsRequest{
+		ScaledObjectRef: &pb.ScaledObjectRef{
+			Name: "vllm-so",
+			ScalerMetadata: map[string]string{
+				"metricType":   "vllm_queue_depth",
+				"vllmEndpoint": ts.URL,
+				"targetValue":  "5",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetMetrics() error = %v", err)
+	}
+	if len(resp.MetricValues) == 0 {
+		t.Fatal("GetMetrics() returned no metric values")
+	}
+	if resp.MetricValues[0].MetricValueFloat != 8 {
+		t.Errorf("queue depth = %v, want 8", resp.MetricValues[0].MetricValueFloat)
+	}
+}
+
+func TestGetMetrics_VLLMKVCacheUsage(t *testing.T) {
+	ts := fakeVLLMServer()
+	defer ts.Close()
+
+	s := NewGPUExternalScaler(gpu.NewMockCollector(testDevices), zap.NewNop())
+	resp, err := s.GetMetrics(context.Background(), &pb.GetMetricsRequest{
+		ScaledObjectRef: &pb.ScaledObjectRef{
+			Name: "vllm-kv-so",
+			ScalerMetadata: map[string]string{
+				"metricType":   "vllm_kv_cache_usage",
+				"vllmEndpoint": ts.URL,
+				"targetValue":  "80",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetMetrics() error = %v", err)
+	}
+	if len(resp.MetricValues) == 0 {
+		t.Fatal("GetMetrics() returned no metric values")
+	}
+	// 0.72 * 100 = 72
+	got := resp.MetricValues[0].MetricValueFloat
+	if math.Abs(got-72) > 0.1 {
+		t.Errorf("kv_cache_usage = %v, want 72", got)
+	}
+}
+
+func TestIsActive_VLLMQueueDepth(t *testing.T) {
+	ts := fakeVLLMServer()
+	defer ts.Close()
+
+	s := NewGPUExternalScaler(gpu.NewMockCollector(testDevices), zap.NewNop())
+
+	// Queue depth is 8, activation threshold is 1 → active
+	resp, err := s.IsActive(context.Background(), &pb.ScaledObjectRef{
+		Name: "vllm-so",
+		ScalerMetadata: map[string]string{
+			"metricType":          "vllm_queue_depth",
+			"vllmEndpoint":        ts.URL,
+			"activationThreshold": "1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("IsActive() error = %v", err)
+	}
+	if !resp.Result {
+		t.Error("IsActive() = false, want true (queue depth 8 > threshold 1)")
+	}
+}
+
+func TestParseMetadata_VLLMMissingEndpoint(t *testing.T) {
+	_, err := parseMetadata(map[string]string{
+		"metricType": "vllm_queue_depth",
+	})
+	if err == nil {
+		t.Error("parseMetadata() should fail when vllmEndpoint is missing for vLLM metric")
+	}
+}
+
+func TestParseMetadata_VLLMWithEndpoint(t *testing.T) {
+	cfg, err := parseMetadata(map[string]string{
+		"metricType":   "vllm_queue_depth",
+		"vllmEndpoint": "http://vllm:8000/metrics",
+	})
+	if err != nil {
+		t.Fatalf("parseMetadata() error = %v", err)
+	}
+	if cfg.metricType != profiles.MetricVLLMQueueDepth {
+		t.Errorf("metricType = %v, want %v", cfg.metricType, profiles.MetricVLLMQueueDepth)
+	}
+	if cfg.vllmEndpoint != "http://vllm:8000/metrics" {
+		t.Errorf("vllmEndpoint = %v, want http://vllm:8000/metrics", cfg.vllmEndpoint)
+	}
+}
+
+func TestGetMetrics_VLLMQueueDepthProfile(t *testing.T) {
+	ts := fakeVLLMServer()
+	defer ts.Close()
+
+	s := NewGPUExternalScaler(gpu.NewMockCollector(testDevices), zap.NewNop())
+	resp, err := s.GetMetrics(context.Background(), &pb.GetMetricsRequest{
+		ScaledObjectRef: &pb.ScaledObjectRef{
+			Name: "vllm-profile-so",
+			ScalerMetadata: map[string]string{
+				"profile":      "vllm-queue-depth",
+				"vllmEndpoint": ts.URL,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetMetrics() error = %v", err)
+	}
+	if len(resp.MetricValues) == 0 {
+		t.Fatal("GetMetrics() returned no metric values")
+	}
+	if resp.MetricValues[0].MetricName != "keda_gpu_vllm_queue_depth" {
+		t.Errorf("metricName = %v, want keda_gpu_vllm_queue_depth", resp.MetricValues[0].MetricName)
+	}
+	if resp.MetricValues[0].MetricValueFloat != 8 {
+		t.Errorf("queue depth = %v, want 8", resp.MetricValues[0].MetricValueFloat)
 	}
 }

--- a/pkg/vllm/client.go
+++ b/pkg/vllm/client.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The keda-gpu-scaler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vllm
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// EngineMetrics holds the metrics scraped from a vLLM instance.
+type EngineMetrics struct {
+	QueueDepth   float64 // vllm:num_requests_waiting
+	RunningCount float64 // vllm:num_requests_running
+	KVCacheUsage float64 // vllm:gpu_cache_usage_perc (0.0–1.0)
+	SwappedCount float64 // vllm:num_requests_swapped
+}
+
+// Client scrapes the vLLM Prometheus metrics endpoint.
+type Client struct {
+	endpoint   string // e.g. "http://vllm-svc:8000/metrics"
+	httpClient *http.Client
+	logger     *zap.Logger
+}
+
+// NewClient creates a vLLM metrics client. endpoint is the full URL
+// including path, e.g. "http://vllm-svc:8000/metrics".
+func NewClient(endpoint string, logger *zap.Logger) *Client {
+	return &Client{
+		endpoint: endpoint,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+		logger: logger,
+	}
+}
+
+// Scrape fetches and parses the vLLM metrics endpoint.
+func (c *Client) Scrape() (EngineMetrics, error) {
+	resp, err := c.httpClient.Get(c.endpoint)
+	if err != nil {
+		return EngineMetrics{}, fmt.Errorf("vllm metrics request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return EngineMetrics{}, fmt.Errorf("vllm metrics returned %d", resp.StatusCode)
+	}
+
+	return parseMetrics(resp.Body)
+}
+
+// parseMetrics reads Prometheus exposition text and pulls the vLLM metrics
+// we care about. Ignores everything else.
+func parseMetrics(r io.Reader) (EngineMetrics, error) {
+	var m EngineMetrics
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+
+		name, value, ok := parseLine(line)
+		if !ok {
+			continue
+		}
+
+		switch name {
+		case "vllm:num_requests_waiting":
+			m.QueueDepth = value
+		case "vllm:num_requests_running":
+			m.RunningCount = value
+		case "vllm:gpu_cache_usage_perc":
+			m.KVCacheUsage = value
+		case "vllm:num_requests_swapped":
+			m.SwappedCount = value
+		}
+	}
+	return m, scanner.Err()
+}
+
+// parseLine extracts metric name and value from a Prometheus text line.
+// Handles both bare metrics ("name value") and labeled metrics ("name{...} value").
+func parseLine(line string) (string, float64, bool) {
+	// Strip label block if present: "name{label=val} 42" → "name 42"
+	nameEnd := strings.IndexByte(line, '{')
+	var rest string
+	if nameEnd >= 0 {
+		closing := strings.IndexByte(line[nameEnd:], '}')
+		if closing < 0 {
+			return "", 0, false
+		}
+		rest = line[:nameEnd] + line[nameEnd+closing+1:]
+	} else {
+		rest = line
+	}
+
+	parts := strings.Fields(rest)
+	if len(parts) < 2 {
+		return "", 0, false
+	}
+	v, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil {
+		return "", 0, false
+	}
+	return parts[0], v, true
+}

--- a/pkg/vllm/client_test.go
+++ b/pkg/vllm/client_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026 The keda-gpu-scaler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vllm
+
+import (
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+const sampleMetrics = `# HELP vllm:num_requests_waiting Number of requests waiting
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{model_name="meta-llama/Llama-2-7b-chat-hf"} 12
+# HELP vllm:num_requests_running Number of requests running
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{model_name="meta-llama/Llama-2-7b-chat-hf"} 3
+# HELP vllm:gpu_cache_usage_perc GPU cache usage
+# TYPE vllm:gpu_cache_usage_perc gauge
+vllm:gpu_cache_usage_perc 0.87
+# HELP vllm:num_requests_swapped Number of requests swapped
+# TYPE vllm:num_requests_swapped gauge
+vllm:num_requests_swapped 0
+`
+
+func TestParseMetrics(t *testing.T) {
+	m, err := parseMetrics(strings.NewReader(sampleMetrics))
+	if err != nil {
+		t.Fatalf("parseMetrics() error = %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"QueueDepth", m.QueueDepth, 12},
+		{"RunningCount", m.RunningCount, 3},
+		{"KVCacheUsage", m.KVCacheUsage, 0.87},
+		{"SwappedCount", m.SwappedCount, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if math.Abs(tt.got-tt.want) > 0.001 {
+				t.Errorf("%s = %v, want %v", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMetrics_NoLabels(t *testing.T) {
+	input := `vllm:num_requests_waiting 5
+vllm:gpu_cache_usage_perc 0.42
+`
+	m, err := parseMetrics(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("parseMetrics() error = %v", err)
+	}
+	if m.QueueDepth != 5 {
+		t.Errorf("QueueDepth = %v, want 5", m.QueueDepth)
+	}
+	if math.Abs(m.KVCacheUsage-0.42) > 0.001 {
+		t.Errorf("KVCacheUsage = %v, want 0.42", m.KVCacheUsage)
+	}
+}
+
+func TestParseMetrics_Empty(t *testing.T) {
+	m, err := parseMetrics(strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("parseMetrics() error = %v", err)
+	}
+	// All zero when nothing is parsed.
+	if m.QueueDepth != 0 || m.RunningCount != 0 || m.KVCacheUsage != 0 {
+		t.Errorf("expected zero values for empty input, got %+v", m)
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	tests := []struct {
+		line   string
+		name   string
+		value  float64
+		wantOK bool
+	}{
+		{`vllm:num_requests_waiting{model_name="foo"} 12`, "vllm:num_requests_waiting", 12, true},
+		{`vllm:gpu_cache_usage_perc 0.87`, "vllm:gpu_cache_usage_perc", 0.87, true},
+		{`# TYPE vllm:num_requests_waiting gauge`, "", 0, false},
+		{``, "", 0, false},
+		{`broken`, "", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			name, value, ok := parseLine(tt.line)
+			if ok != tt.wantOK {
+				t.Fatalf("parseLine(%q) ok = %v, want %v", tt.line, ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if name != tt.name {
+				t.Errorf("name = %q, want %q", name, tt.name)
+			}
+			if math.Abs(value-tt.value) > 0.001 {
+				t.Errorf("value = %v, want %v", value, tt.value)
+			}
+		})
+	}
+}
+
+func TestClient_Scrape(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleMetrics))
+	}))
+	defer ts.Close()
+
+	c := NewClient(ts.URL, zap.NewNop())
+	m, err := c.Scrape()
+	if err != nil {
+		t.Fatalf("Scrape() error = %v", err)
+	}
+	if m.QueueDepth != 12 {
+		t.Errorf("QueueDepth = %v, want 12", m.QueueDepth)
+	}
+	if m.RunningCount != 3 {
+		t.Errorf("RunningCount = %v, want 3", m.RunningCount)
+	}
+}
+
+func TestClient_Scrape_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	c := NewClient(ts.URL, zap.NewNop())
+	_, err := c.Scrape()
+	if err == nil {
+		t.Error("Scrape() expected error for 500 response, got nil")
+	}
+}
+
+func TestClient_Scrape_Unreachable(t *testing.T) {
+	c := NewClient("http://127.0.0.1:1", zap.NewNop())
+	_, err := c.Scrape()
+	if err == nil {
+		t.Error("Scrape() expected error for unreachable endpoint, got nil")
+	}
+}


### PR DESCRIPTION
Add a new pkg/vllm HTTP client that scrapes vLLM's Prometheus-style /metrics endpoint for queue depth (num_requests_waiting), running request count, KV cache usage, and swapped request count.

Integrate vLLM metrics into the scaler server: when metricType is vllm_queue_depth or vllm_kv_cache_usage, the scaler routes to the vLLM client instead of NVML. Clients are cached per endpoint URL.

Add vllm-queue-depth built-in profile (target: 5 pending requests,
activation: 1) for simple ScaledObject configuration.

Validation enforces that vllmEndpoint metadata is required when using vLLM metric types.

Includes unit tests for:
- vLLM metric parsing from Prometheus exposition format
- HTTP scraping with mock server
- Scaler integration: GetMetrics, IsActive, profile resolution
- Metadata validation for missing endpoint

## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

<!-- Describe your changes -->

## Related Issue

<!-- Link to related issue: Fixes #123 or Ref #123 -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] Commits are signed off (`git commit -s`)

## Contributor Info

<!-- We recognize all contributors in CONTRIBUTORS.md and on the project page.
     Please fill in what you're comfortable sharing so we can properly credit you. -->

- **Name:**
- **Location:** <!-- optional -->
- **Company / Affiliation:** <!-- optional -->

<!-- First-time contributor? A ⭐ on the repo helps other contributors discover the project! -->
- [x] I have starred the [keda-gpu-scaler](https://github.com/pmady/keda-gpu-scaler) repository
