### PR TITLE
feat: add GPU driver version to gpu-metrics output

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ Every environment emits the same unified JSON schema with an `environment` block
 ```json
 {
   "environment": { "orchestrator": "slurm", "node": "compute-01", "job_id": "123", "task_rank": 0 },
+  "driver_version": "535.104.05",
   "collected_at": "2026-06-17T10:00:00Z",
   "devices": [...]
 }

--- a/cmd/gpu-metrics/main.go
+++ b/cmd/gpu-metrics/main.go
@@ -95,7 +95,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "collection failed: %v\n", err)
 			os.Exit(1)
 		}
-		output(metrics, *format, envCtx)
+		output(metrics, *format, envCtx, collector.DriverVersion())
 		return
 	}
 
@@ -111,7 +111,7 @@ func main() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "collection failed: %v\n", err)
 		} else {
-			output(metrics, *format, envCtx)
+			output(metrics, *format, envCtx, collector.DriverVersion())
 		}
 
 		select {
@@ -238,14 +238,14 @@ func collectDevices(c gpu.MetricsCollector, devs []int) ([]gpu.Metrics, error) {
 	return out, nil
 }
 
-func output(metrics []gpu.Metrics, format string, envCtx env.Context) {
+func output(metrics []gpu.Metrics, format string, envCtx env.Context, driverVersion string) {
 	switch format {
 	case "json":
-		outputJSON(metrics, envCtx)
+		outputJSON(metrics, envCtx, driverVersion)
 	case "csv":
 		outputCSV(metrics, envCtx)
 	default:
-		outputTable(metrics, envCtx)
+		outputTable(metrics, envCtx, driverVersion)
 	}
 }
 
@@ -253,18 +253,20 @@ func output(metrics []gpu.Metrics, format string, envCtx env.Context) {
 // The "environment" block lets consumers compare runs from different
 // orchestrators without any schema changes.
 type jsonOutput struct {
-	Environment env.Context   `json:"environment"`
-	CollectedAt time.Time     `json:"collected_at"`
-	Devices     []gpu.Metrics `json:"devices"`
+	Environment   env.Context   `json:"environment"`
+	DriverVersion string        `json:"driver_version,omitempty"`
+	CollectedAt   time.Time     `json:"collected_at"`
+	Devices       []gpu.Metrics `json:"devices"`
 }
 
-func outputJSON(metrics []gpu.Metrics, envCtx env.Context) {
+func outputJSON(metrics []gpu.Metrics, envCtx env.Context, driverVersion string) {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(jsonOutput{
-		Environment: envCtx,
-		CollectedAt: time.Now().UTC(),
-		Devices:     metrics,
+		Environment:   envCtx,
+		DriverVersion: driverVersion,
+		CollectedAt:   time.Now().UTC(),
+		Devices:       metrics,
 	})
 }
 
@@ -282,7 +284,7 @@ func outputCSV(metrics []gpu.Metrics, envCtx env.Context) {
 	w.Flush()
 }
 
-func outputTable(metrics []gpu.Metrics, envCtx env.Context) {
+func outputTable(metrics []gpu.Metrics, envCtx env.Context, driverVersion string) {
 	// Print environment banner.
 	fmt.Printf("Environment : %s", envCtx.Orchestrator)
 	if envCtx.NodeName != "" {
@@ -299,6 +301,9 @@ func outputTable(metrics []gpu.Metrics, envCtx env.Context) {
 	}
 	if envCtx.Partition != "" {
 		fmt.Printf("  |  Partition: %s", envCtx.Partition)
+	}
+	if driverVersion != "" {
+		fmt.Printf("  |  Driver: %s", driverVersion)
 	}
 	fmt.Println()
 	fmt.Println()

--- a/cmd/gpu-metrics/main.go
+++ b/cmd/gpu-metrics/main.go
@@ -243,7 +243,7 @@ func output(metrics []gpu.Metrics, format string, envCtx env.Context, driverVers
 	case "json":
 		outputJSON(metrics, envCtx, driverVersion)
 	case "csv":
-		outputCSV(metrics, envCtx)
+		outputCSV(metrics, envCtx, driverVersion)
 	default:
 		outputTable(metrics, envCtx, driverVersion)
 	}
@@ -270,15 +270,17 @@ func outputJSON(metrics []gpu.Metrics, envCtx env.Context, driverVersion string)
 	})
 }
 
-func outputCSV(metrics []gpu.Metrics, envCtx env.Context) {
+func outputCSV(metrics []gpu.Metrics, envCtx env.Context, driverVersion string) {
 	w := csv.NewWriter(os.Stdout)
 
-	// Environment columns prefix GPU columns.
-	hdr := append(envCtx.Header(), csvHeader()...)
+	// Environment + driver columns prefix the per-GPU columns.
+	hdr := append(envCtx.Header(), "driver_version")
+	hdr = append(hdr, csvHeader()...)
 	_ = w.Write(hdr)
 
 	for _, m := range metrics {
-		row := append(envCtx.Row(), csvRow(m)...)
+		row := append(envCtx.Row(), driverVersion)
+		row = append(row, csvRow(m)...)
 		_ = w.Write(row)
 	}
 	w.Flush()

--- a/cmd/gpu-metrics/main_test.go
+++ b/cmd/gpu-metrics/main_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -117,5 +118,25 @@ func TestPrintDryRunRendersSchedulerContext(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("dry-run output missing %q\n--- output ---\n%s", want, out)
 		}
+	}
+}
+
+// The driver version (issue #68) must appear in the JSON output when present
+// and be omitted when empty (omitempty).
+func TestJSONOutputDriverVersion(t *testing.T) {
+	withDriver, err := json.Marshal(jsonOutput{DriverVersion: "535.104.05"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(withDriver), `"driver_version":"535.104.05"`) {
+		t.Errorf("driver_version missing from JSON output: %s", withDriver)
+	}
+
+	noDriver, err := json.Marshal(jsonOutput{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(noDriver), "driver_version") {
+		t.Errorf("empty driver_version should be omitted, got: %s", noDriver)
 	}
 }

--- a/cmd/gpu-metrics/main_test.go
+++ b/cmd/gpu-metrics/main_test.go
@@ -19,11 +19,14 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/pmady/keda-gpu-scaler/pkg/env"
+	"github.com/pmady/keda-gpu-scaler/pkg/gpu"
 )
 
 func TestDescribeDeviceFilter(t *testing.T) {
@@ -138,5 +141,60 @@ func TestJSONOutputDriverVersion(t *testing.T) {
 	}
 	if strings.Contains(string(noDriver), "driver_version") {
 		t.Errorf("empty driver_version should be omitted, got: %s", noDriver)
+	}
+}
+
+// captureStdout redirects os.Stdout while fn runs and returns what it wrote.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	return buf.String()
+}
+
+// The driver version must appear in the table banner when present and be
+// omitted when empty (issue #68).
+func TestOutputTableDriverVersion(t *testing.T) {
+	devices := []gpu.Metrics{{Index: 0, Name: "A100"}}
+
+	withDriver := captureStdout(t, func() {
+		outputTable(devices, env.Context{Orchestrator: "standalone"}, "535.104.05")
+	})
+	if !strings.Contains(withDriver, "Driver: 535.104.05") {
+		t.Errorf("table banner missing driver version\n--- output ---\n%s", withDriver)
+	}
+
+	noDriver := captureStdout(t, func() {
+		outputTable(devices, env.Context{Orchestrator: "standalone"}, "")
+	})
+	if strings.Contains(noDriver, "Driver:") {
+		t.Errorf("empty driver version should not appear in banner\n--- output ---\n%s", noDriver)
+	}
+}
+
+// The driver version must be a CSV column (header + value) for parity with the
+// JSON and table outputs.
+func TestOutputCSVDriverVersion(t *testing.T) {
+	out := captureStdout(t, func() {
+		outputCSV([]gpu.Metrics{{Index: 0, Name: "A100"}}, env.Context{Orchestrator: "standalone"}, "535.104.05")
+	})
+	if !strings.Contains(out, "driver_version") {
+		t.Errorf("CSV header missing driver_version column\n--- output ---\n%s", out)
+	}
+	if !strings.Contains(out, "535.104.05") {
+		t.Errorf("CSV row missing driver version value\n--- output ---\n%s", out)
 	}
 }

--- a/pkg/gpu/nvml.go
+++ b/pkg/gpu/nvml.go
@@ -55,8 +55,9 @@ type Metrics struct {
 
 // Collector wraps NVML to collect GPU metrics.
 type Collector struct {
-	logger *zap.Logger
-	mu     sync.Mutex
+	logger        *zap.Logger
+	mu            sync.Mutex
+	driverVersion string
 }
 
 // NewCollector creates a new GPU metrics collector.
@@ -66,7 +67,26 @@ func NewCollector(logger *zap.Logger) (*Collector, error) {
 		return nil, fmt.Errorf("failed to initialize NVML: %v", nvml.ErrorString(ret))
 	}
 	logger.Info("NVML initialized successfully")
-	return &Collector{logger: logger}, nil
+
+	// The NVIDIA driver version is node-wide and fixed for the life of the
+	// process, so read it once here. A failure is non-fatal — metric collection
+	// still works without it.
+	driverVersion, ret := nvml.SystemGetDriverVersion()
+	if ret != nvml.SUCCESS {
+		logger.Warn("failed to read NVML driver version",
+			zap.String("nvml_error", nvml.ErrorString(ret)))
+		driverVersion = ""
+	} else {
+		logger.Info("NVIDIA driver detected", zap.String("driver_version", driverVersion))
+	}
+
+	return &Collector{logger: logger, driverVersion: driverVersion}, nil
+}
+
+// DriverVersion returns the NVIDIA driver version reported by NVML at startup,
+// or an empty string if it could not be read.
+func (c *Collector) DriverVersion() string {
+	return c.driverVersion
 }
 
 // Close shuts down the NVML library.


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

Surfaces the NVIDIA driver version (from `nvml.SystemGetDriverVersion()`) in the `gpu-metrics` output, which helps debug driver issues on mixed-GPU clusters.

- **Collector:** read the driver version once in `NewCollector()` (it's node-wide and fixed for the process lifetime), cache it on the `Collector`, and expose it via a new `DriverVersion()` accessor. A read failure is non-fatal — metric collection still works without it.
- **Output (all three formats):**
  - JSON — a top-level `"driver_version"` field (`omitempty`)
  - Table — a `Driver: <version>` entry in the environment banner
  - CSV — a `driver_version` column (header + value)

The driver version is system-level, so it lives at the top level / banner / a prefix column rather than being repeated as per-GPU data.

## Related Issue

Closes #68

## Notes for reviewers

- **Scope:** the issue listed `pkg/gpu/nvml.go` + `cmd/gpu-metrics/main.go`. No interface or mock change was needed because `NewCollector` returns the concrete `*Collector`, so `gpu-metrics` calls `DriverVersion()` directly.
- **CSV** wasn't in the issue's literal "JSON + table" list; I added it for output parity (it's a small column add). Easy to drop if you'd rather keep CSV unchanged.
- The README's example JSON block doesn't show `driver_version` yet — happy to add it as a quick follow-up if you'd like the docs example updated.

## Checklist

- [x] Tests added/updated <!-- JSON/table/CSV output all covered via stdout capture -->
- [ ] Documentation updated (if applicable) <!-- README JSON example could be updated; see notes -->
- [x] `make test` passes
- [x] `make lint` passes <!-- golangci-lint: 0 issues -->
- [x] Commits are signed off (`git commit -s`)