### PR TITLE
test: add edge case coverage for parseMetadata

### DIFF
--- a/pkg/scaler/server_test.go
+++ b/pkg/scaler/server_test.go
@@ -236,6 +236,15 @@ func TestParseMetadata(t *testing.T) {
 			},
 		},
 		{
+			name: "very large targetValue accepted",
+			metadata: map[string]string{
+				"targetValue": "1000000",
+			},
+			want: scalerConfig{
+				metricName:          "keda_gpu_metric",
+				metricType:          profiles.MetricGPUUtilization,
+		},
+		{
 			name: "pollIntervalSeconds zero accepted",
 			metadata: map[string]string{
 				"pollIntervalSeconds": "0",
@@ -257,7 +266,7 @@ func TestParseMetadata(t *testing.T) {
 				"metricType": "temperature",
 			},
 			want: scalerConfig{
-				metricName:          "keda_gpu_vllm_inference",  // this is same as profile name
+				metricName:          "keda_gpu_vllm_inference",  // from profile
 				metricType:          profiles.MetricTemperature, // overridden
 				targetValue:         80,                         // from profile
 				activationThreshold: 5,                          // from profile

--- a/pkg/scaler/server_test.go
+++ b/pkg/scaler/server_test.go
@@ -199,6 +199,73 @@ func TestParseMetadata(t *testing.T) {
 				pollIntervalSeconds: 10,
 			},
 		},
+		{
+			name: "empty string targetValue",
+			metadata: map[string]string{
+				"targetValue": "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty string gpuIndex",
+			metadata: map[string]string{
+				"gpuIndex": "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty string pollIntervalSeconds",
+			metadata: map[string]string{
+				"pollIntervalSeconds": "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative gpuIndex accepted (no range check in parseMetadata)",
+			metadata: map[string]string{
+				"gpuIndex": "-2",
+			},
+			want: scalerConfig{
+				metricName:          "keda_gpu_metric",
+				metricType:          profiles.MetricGPUUtilization,
+				targetValue:         80,
+				activationThreshold: 0,
+				gpuIndex:            -2,
+				aggregation:         "max",
+				pollIntervalSeconds: 10,
+			},
+		},
+		{
+			name: "pollIntervalSeconds zero accepted",
+			metadata: map[string]string{
+				"pollIntervalSeconds": "0",
+			},
+			want: scalerConfig{
+				metricName:          "keda_gpu_metric",
+				metricType:          profiles.MetricGPUUtilization,
+				targetValue:         80,
+				activationThreshold: 0,
+				gpuIndex:            -1,
+				aggregation:         "max",
+				pollIntervalSeconds: 0,
+			},
+		},
+		{
+			name: "profile with metricType override",
+			metadata: map[string]string{
+				"profile":    "vllm-inference",
+				"metricType": "temperature",
+			},
+			want: scalerConfig{
+				metricName:          "keda_gpu_vllm_inference",  // this is same as profile name
+				metricType:          profiles.MetricTemperature, // overridden
+				targetValue:         80,                         // from profile
+				activationThreshold: 5,                          // from profile
+				gpuIndex:            -1,
+				aggregation:         "max",
+				pollIntervalSeconds: 10,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scaler/server_test.go
+++ b/pkg/scaler/server_test.go
@@ -243,6 +243,12 @@ func TestParseMetadata(t *testing.T) {
 			want: scalerConfig{
 				metricName:          "keda_gpu_metric",
 				metricType:          profiles.MetricGPUUtilization,
+				targetValue:         1000000,
+				activationThreshold: 0,
+				gpuIndex:            -1,
+				aggregation:         "max",
+				pollIntervalSeconds: 10,
+			},
 		},
 		{
 			name: "pollIntervalSeconds zero accepted",


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactoring
- [ ] CI/Build

## Description

Adds test cases to `TestParseMetadata` n `pkg/scaler/server_test.go` covering edge cases mentioned in [here](https://github.com/pmady/keda-gpu-scaler/issues/67#issue-4727193567).

**Note**: The "empty metadata map (should use all defaults)" and "profile name that doesnt exist" from the issue's checklist was already covered by existing test cases (`defaults with no metadata` and `unknown profile` in `TestParseMetadata`) 

No production logic was changed.

## Related Issue

Fixes #67

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable)
- [x] `make test` passes
- [x] `make lint` passes
- [x] Commits are signed off (`git commit -s`)

## Contributor Info

<!-- We recognize all contributors in CONTRIBUTORS.md and on the project page.
     Please fill in what you're comfortable sharing so we can properly credit you. -->

- **Name:** Pavan Sorab
- **Location:** India

<!-- First-time contributor? A ⭐ on the repo helps other contributors discover the project! -->
- [x] I have starred the [keda-gpu-scaler](https://github.com/pmady/keda-gpu-scaler) repository
