### PR TITLE
docs+test: document and cover vLLM queue depth scaling (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **MIG (Multi-Instance GPU) per-instance metrics**. `CollectAll()` auto-detects MIG-enabled GPUs and enumerates each compute instance via NVML, returning one `Metrics` entry per instance instead of one per physical GPU. Shared chip-level metrics (temperature, power, PCIe, NVLink) are read from the parent GPU and copied into every instance. In HPC environments (SLURM, Flux), MIG UUIDs in `CUDA_VISIBLE_DEVICES` are detected and resolved individually via `CollectByUUID()`. New `Metrics` fields: `IsMIGInstance`, `ParentIndex`, `MigProfile`. New CSV columns: `is_mig_instance`, `parent_index`, `mig_profile`. Table output shows `gpu<N>/inst<M>` labels for MIG rows.
+- **vLLM queue depth and KV cache usage scaling** (`pkg/vllm`). Reads pending request count directly from the vLLM engine's Prometheus `/metrics` endpoint instead of relying on GPU utilization as a proxy, for faster scaling reaction time ([#28](https://github.com/pmady/keda-gpu-scaler/issues/28)). New `vllm_queue_depth` (`vllm:num_requests_waiting`) and `vllm_kv_cache_usage` (`vllm:gpu_cache_usage_perc`) metric types, a new `vllmEndpoint` trigger parameter, and a `vllm-queue-depth` pre-built profile. vLLM clients are cached per endpoint on the scaler.
 
 ## [v0.5.0] - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ This design is documented in [KEDA issue #7538](https://github.com/kedacore/keda
 | `pcie_rx_kbps` | PCIe receive throughput (GPU→CPU) | KB/s |
 | `nvlink_tx_mbps` | NVLink transmit throughput (GPU→GPU) | MB/s |
 | `nvlink_rx_mbps` | NVLink receive throughput (GPU→GPU) | MB/s |
+| `vllm_queue_depth` | Pending requests waiting in the vLLM engine — requires `vllmEndpoint` | count |
+| `vllm_kv_cache_usage` | vLLM GPU KV cache usage — requires `vllmEndpoint` | % (0-100) |
+
+The `vllm_*` metrics come from the vLLM engine's own `/metrics` endpoint
+rather than NVML — see [docs/configuration.md](docs/configuration.md#vllm-engine-metrics).
 
 ---
 
@@ -73,6 +78,7 @@ Instead of configuring raw metric thresholds, use a profile optimized for your w
 | Profile | Primary Metric | Target | Activation | Use Case |
 |---------|---------------|--------|------------|----------|
 | `vllm-inference` | Memory % | 80 | 5 | vLLM / LLM serving with scale-to-zero |
+| `vllm-queue-depth` | Pending requests | 5 | 1 | vLLM — scale on queue depth via the engine API for faster reaction time |
 | `triton-inference` | GPU Util | 75 | 10 | NVIDIA Triton Inference Server |
 | `training` | GPU Util | 90 | 0 | Training jobs (no scale-to-zero) |
 | `batch` | Memory % | 70 | 1 | Batch inference with aggressive scale-down |
@@ -393,7 +399,7 @@ Using keda-gpu-scaler? Add your organization to [ADOPTERS.md](ADOPTERS.md).
 
 - AMD ROCm support
 - MIG per-instance metrics
-- vLLM queue depth scaling
+- ~~vLLM queue depth scaling~~ — available via the `vllm_queue_depth` metric type / `vllm-queue-depth` profile; see [docs/configuration.md](docs/configuration.md#vllm-engine-metrics)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ Technical direction for keda-gpu-scaler. Updated as priorities shift.
 
 - ✅ **MIG support** — Per-instance metrics for Multi-Instance GPU partitions. `CollectAll` enumerates MIG compute instances automatically; HPC environments resolve MIG UUIDs via `CollectByUUID`. ([#26](https://github.com/pmady/keda-gpu-scaler/issues/26))
 - **New scaling profiles** — TGI, Ollama ([#64](https://github.com/pmady/keda-gpu-scaler/issues/64), [#65](https://github.com/pmady/keda-gpu-scaler/issues/65))
-- **vLLM queue depth** — Scale on pending requests via vLLM engine API ([#28](https://github.com/pmady/keda-gpu-scaler/issues/28))
+- ✅ **vLLM queue depth** — Scale on pending requests via vLLM engine API. `pkg/vllm` scrapes `vllm:num_requests_waiting` (and `vllm:gpu_cache_usage_perc`) from the engine's `/metrics` endpoint; new `vllm_queue_depth` / `vllm_kv_cache_usage` metric types and the `vllm-queue-depth` profile expose it to KEDA. ([#28](https://github.com/pmady/keda-gpu-scaler/issues/28))
 - **Improved aggregation** — p95, p99 percentile methods ([#69](https://github.com/pmady/keda-gpu-scaler/issues/69))
 - **CI/CD hardening** — golangci-lint config, go vet, test coverage, pre-commit hooks ([#72](https://github.com/pmady/keda-gpu-scaler/issues/72), [#73](https://github.com/pmady/keda-gpu-scaler/issues/73), [#74](https://github.com/pmady/keda-gpu-scaler/issues/74), [#76](https://github.com/pmady/keda-gpu-scaler/issues/76))
 - **Grafana dashboard** for GPU fleet visibility ([#29](https://github.com/pmady/keda-gpu-scaler/issues/29))

--- a/deploy/examples/vllm-queue-depth-scaledobject.yaml
+++ b/deploy/examples/vllm-queue-depth-scaledobject.yaml
@@ -1,0 +1,32 @@
+# Example: ScaledObject for a vLLM inference deployment that scales on
+# pending request count (queue depth), read directly from the vLLM engine's
+# own metrics endpoint instead of GPU utilization/memory.
+#
+# Prerequisites:
+#   - keda-gpu-scaler DaemonSet running (kubectl apply -f deploy/manifests.yaml)
+#   - KEDA v2.10+ installed
+#   - A Deployment named "vllm-deepseek-deployment" in the "ai-workloads" namespace,
+#     with a Service exposing vLLM's Prometheus metrics endpoint (default :8000/metrics)
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: vllm-queue-depth-scaler
+  namespace: ai-workloads
+spec:
+  scaleTargetRef:
+    name: vllm-deepseek-deployment
+  minReplicaCount: 1
+  maxReplicaCount: 50
+  cooldownPeriod: 30
+  triggers:
+    - type: external
+      metadata:
+        # Points to the Service created by deploy/manifests.yaml
+        scalerAddress: "keda-gpu-scaler.keda.svc.cluster.local:6000"
+        # Use the pre-built vLLM queue-depth profile (target: 5 pending
+        # requests, activation: 1). Override targetValue/activationThreshold
+        # here to tune for your workload.
+        profile: "vllm-queue-depth"
+        # The vLLM engine's own metrics endpoint — required for
+        # vllm_queue_depth / vllm_kv_cache_usage metric types.
+        vllmEndpoint: "http://vllm-deepseek-deployment:8000/metrics"

--- a/deploy/helm/keda-gpu-scaler/README.md
+++ b/deploy/helm/keda-gpu-scaler/README.md
@@ -49,8 +49,14 @@ triggers:
       profile: "vllm-inference"
 ```
 
-Available profiles: `vllm-inference`, `triton-inference`, `training`, `batch`,
-`distributed-training`.
+Available profiles: `vllm-inference`, `vllm-queue-depth`, `triton-inference`,
+`training`, `batch`, `distributed-training`.
+
+`vllm-queue-depth` scales on pending requests read from the vLLM engine's own
+metrics endpoint rather than GPU utilization/memory, and requires a
+`vllmEndpoint` trigger parameter pointing at it (e.g.
+`http://vllm-deployment:8000/metrics`) — see the repo's
+`docs/configuration.md#vllm-engine-metrics`.
 
 ## Parameters
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -77,6 +77,7 @@ Raw metric thresholds are error-prone if you don't know what "80% GPU utilizatio
 | Profile | What it optimizes for |
 |---------|----------------------|
 | `vllm-inference` | LLM serving. Scales on VRAM pressure (80%) because vLLM pre-allocates KV cache. Activation threshold at 5% for scale-to-zero. |
+| `vllm-queue-depth` | LLM serving. Scales on pending requests (target 5) read from the vLLM engine API — faster reaction than waiting for VRAM/utilization to move. Activation at 1 request. |
 | `triton-inference` | Multi-model serving. Scales on SM utilization (75%) because Triton shares GPU across models. Higher activation (10%) to avoid flapping. |
 | `training` | Batch training. Scales on SM utilization (90%) with no scale-to-zero (activation 0) to avoid killing checkpoints. |
 | `batch` | Offline batch inference. Aggressive scale-down with 70% memory threshold and low activation (1%). |
@@ -168,8 +169,16 @@ Extra `Metrics` fields: `IsMIGInstance` (bool), `ParentIndex` (int, -1 for UUID 
 
 If MIG is enabled but no instances exist (GPU not yet partitioned), `collectMIGInstances` logs a warning and returns nothing. `CollectDevice()` on MIG GPUs returns physical-level metrics only and logs a warning.
 
+## vLLM Engine Metrics (`pkg/vllm`)
+
+GPU utilization and VRAM are proxies for load on a vLLM server — they say the GPU is busy, not how many requests are actually queued. vLLM exposes the real signal on its own Prometheus `/metrics` endpoint, so `pkg/vllm.Client` scrapes it directly instead of routing through NVML.
+
+`Client.Scrape()` fetches the vLLM engine's metrics endpoint and parses the exposition-format text into an `EngineMetrics` struct, pulling `vllm:num_requests_waiting` (queue depth), `vllm:num_requests_running`, `vllm:gpu_cache_usage_perc` (KV cache usage), and `vllm:num_requests_swapped`; everything else is ignored. `getVLLMMetricValue` in `pkg/scaler` maps `vllm_queue_depth` and `vllm_kv_cache_usage` (normalized 0–100) to these fields, and `parseMetadata` requires `vllmEndpoint` whenever the requested `metricType` is one of them. The scaler caches one `vllm.Client` per distinct endpoint rather than reconnecting on every poll.
+
+Because this bypasses NVML entirely, it needs no GPU driver access — only HTTP reachability from the scaler DaemonSet pods to the vLLM Service. See `docs/configuration.md#vllm-engine-metrics` for usage.
+
 ## Future Work
 
 - **AMD ROCm support**: Same DaemonSet pattern, different hardware library (`rocm-smi`)
 - **NVLink topology**: Prefer scaling on nodes with direct GPU-to-GPU interconnect
-- **vLLM queue depth**: Read pending request count directly from vLLM's engine API for more precise scaling
+- ~~**vLLM queue depth**: Read pending request count directly from vLLM's engine API for more precise scaling~~ — implemented as `pkg/vllm` (see above); see `docs/configuration.md#vllm-engine-metrics`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ Everything goes in the ScaledObject trigger `metadata`. No config files or extra
 | `gpuIndex` | Specific GPU index to monitor | `-1` (all GPUs) |
 | `aggregation` | Multi-GPU aggregation: `max`, `min`, `avg`, `sum` | `max` |
 | `pollIntervalSeconds` | Metric polling interval | `10` |
+| `vllmEndpoint` | vLLM engine metrics URL, e.g. `http://vllm-svc:8000/metrics`. Required when `metricType` is `vllm_queue_depth` or `vllm_kv_cache_usage` | (none) |
 
 ### Supported metricType values
 
@@ -30,6 +31,11 @@ Everything goes in the ScaledObject trigger `metadata`. No config files or extra
 | `pcie_rx_kbps` | KB/s | PCIe receive throughput (GPU→CPU) |
 | `nvlink_tx_mbps` | MB/s | Aggregate NVLink transmit throughput across all active links |
 | `nvlink_rx_mbps` | MB/s | Aggregate NVLink receive throughput across all active links |
+| `vllm_queue_depth` | count | Pending requests waiting in the vLLM engine (`vllm:num_requests_waiting`) — requires `vllmEndpoint`, see [vLLM Engine Metrics](#vllm-engine-metrics) |
+| `vllm_kv_cache_usage` | % | vLLM GPU KV cache usage (`vllm:gpu_cache_usage_perc`, normalized to 0-100) — requires `vllmEndpoint`, see [vLLM Engine Metrics](#vllm-engine-metrics) |
+
+The `vllm_*` metrics bypass NVML entirely and are scraped directly from the
+vLLM engine's own metrics endpoint.
 
 ## Scaling Profiles
 
@@ -38,6 +44,7 @@ Profiles bundle defaults for common workloads. Override any parameter in the tri
 | Profile | Primary Metric | Target | Activation | Use Case |
 |---------|---------------|--------|------------|----------|
 | `vllm-inference` | Memory % | 80 | 5 | vLLM / LLM serving with scale-to-zero |
+| `vllm-queue-depth` | Pending requests | 5 | 1 | vLLM — scale on queue depth via the engine API, see [vLLM Engine Metrics](#vllm-engine-metrics) |
 | `triton-inference` | GPU Util | 75 | 10 | NVIDIA Triton Inference Server |
 | `training` | GPU Util | 90 | 0 | Training jobs (no scale-to-zero) |
 | `batch` | Memory % | 70 | 1 | Batch inference with aggressive scale-down |
@@ -114,6 +121,45 @@ triggers:
 ### NVLink availability
 
 On hardware without NVLink (T4, A10, etc.) the NVLink metrics are always `0`. If you configure a ScaledObject with an NVLink metric type on non-NVLink hardware, KEDA will see `0` and scale to zero if `activationThreshold > 0`. Use PCIe metrics on those nodes instead.
+
+## vLLM Engine Metrics
+
+GPU utilization and VRAM usage (the `vllm-inference` profile) are proxies for load — they tell you the GPU is busy, not how many requests are actually waiting. vLLM's own engine exposes that directly via its Prometheus `/metrics` endpoint, and `pkg/vllm` scrapes it so KEDA can scale on the real signal instead of waiting for a utilization or memory spike.
+
+| metricType | Source metric | What it tells you |
+|------------|----------------|--------------------|
+| `vllm_queue_depth` | `vllm:num_requests_waiting` | Requests queued behind the running batch — the most direct signal for "we need more replicas now" |
+| `vllm_kv_cache_usage` | `vllm:gpu_cache_usage_perc` | How full the KV cache is (0-100%) — a leading indicator before requests start queuing |
+
+Both require `vllmEndpoint` — the full URL of the vLLM engine's metrics endpoint (e.g. `http://vllm-svc:8000/metrics`), reachable from the scaler DaemonSet pods. `vllmEndpoint` has nothing to do with NVML: it's a plain HTTP scrape of the inference server itself. `getMetricValue` routes any `vllm_*` metricType to this HTTP client instead of the NVML collector; the scaler keeps one cached client per distinct `vllmEndpoint`.
+
+### Using the vllm-queue-depth profile
+
+```yaml
+triggers:
+  - type: external
+    metadata:
+      scalerAddress: "keda-gpu-scaler.keda.svc.cluster.local:6000"
+      profile: "vllm-queue-depth"
+      vllmEndpoint: "http://vllm-deepseek-deployment:8000/metrics"
+```
+
+### Using vllm_kv_cache_usage directly
+
+```yaml
+triggers:
+  - type: external
+    metadata:
+      scalerAddress: "keda-gpu-scaler.keda.svc.cluster.local:6000"
+      metricType: "vllm_kv_cache_usage"
+      vllmEndpoint: "http://vllm-deepseek-deployment:8000/metrics"
+      targetValue: "80"           # scale out once KV cache is 80% full
+      activationThreshold: "5"
+```
+
+### vllm-inference vs. vllm-queue-depth
+
+Use `vllm-inference` (VRAM-based) as a simple default — it needs no extra endpoint and scale-to-zero works out of the box. Switch to `vllm-queue-depth` (or raw `vllm_queue_depth` / `vllm_kv_cache_usage`) when you want faster reaction to load spikes than VRAM pressure alone provides, and can reach the vLLM engine's metrics port from the scaler's DaemonSet pods.
 
 ## Multi-GPU Aggregation
 
@@ -198,4 +244,5 @@ When `--probe-port` is non-zero, an HTTP server exposes:
 Check `deploy/examples/` for ScaledObject manifests:
 
 - `vllm-scaledobject.yaml` — vLLM inference with scale-to-zero
+- `vllm-queue-depth-scaledobject.yaml` — vLLM queue depth scaling via the engine API
 - `custom-gpu-utilization.yaml` — raw GPU utilization scaling

--- a/tests/e2e/grpc_scaler_test.go
+++ b/tests/e2e/grpc_scaler_test.go
@@ -22,6 +22,8 @@ package e2e
 import (
 	"context"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -666,5 +668,109 @@ func TestAggregationSum(t *testing.T) {
 	got := resp.MetricValues[0].MetricValueFloat
 	if got != 100 {
 		t.Errorf("sum aggregation = %v, want 100", got)
+	}
+}
+
+// fakeVLLMEngine stands in for a vLLM server's Prometheus /metrics endpoint,
+// so the vLLM queue-depth path can be exercised end-to-end through the real
+// gRPC server without needing an actual vLLM deployment (issue #28).
+func fakeVLLMEngine(t *testing.T, body string) (string, func()) {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	return ts.URL, ts.Close
+}
+
+const fakeVLLMEngineMetrics = `# HELP vllm:num_requests_waiting Number of requests waiting
+# TYPE vllm:num_requests_waiting gauge
+vllm:num_requests_waiting{model_name="llama-7b"} 14
+# HELP vllm:gpu_cache_usage_perc GPU KV cache usage
+# TYPE vllm:gpu_cache_usage_perc gauge
+vllm:gpu_cache_usage_perc 0.63
+`
+
+// End-to-end coverage for reading pending request count directly from the
+// vLLM engine API (issue #28): a real gRPC server backed by GPUExternalScaler
+// scrapes a fake vLLM metrics endpoint and reports queue depth through
+// IsActive / GetMetricSpec / GetMetrics, exactly as KEDA would consume it.
+func TestVLLMQueueDepthE2E(t *testing.T) {
+	vllmURL, vllmCleanup := fakeVLLMEngine(t, fakeVLLMEngineMetrics)
+	defer vllmCleanup()
+
+	// GPU devices are irrelevant for this metric type but the collector
+	// still needs at least one so unrelated calls on the same server don't
+	// error out.
+	devices := []gpu.Metrics{{Index: 0, GPUUtilization: 10}}
+	addr, cleanup := startTestServer(t, devices)
+	defer cleanup()
+
+	conn, client := dialScaler(t, addr)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	metadata := map[string]string{
+		"profile":      "vllm-queue-depth",
+		"vllmEndpoint": vllmURL,
+	}
+	ref := &pb.ScaledObjectRef{
+		Name:           "vllm-e2e-test",
+		Namespace:      "ai-workloads",
+		ScalerMetadata: metadata,
+	}
+
+	specResp, err := client.GetMetricSpec(ctx, ref)
+	if err != nil {
+		t.Fatalf("GetMetricSpec failed: %v", err)
+	}
+	if len(specResp.MetricSpecs) != 1 || specResp.MetricSpecs[0].MetricName != "keda_gpu_vllm_queue_depth" {
+		t.Fatalf("GetMetricSpec = %+v, want metric name keda_gpu_vllm_queue_depth", specResp.MetricSpecs)
+	}
+
+	metricsResp, err := client.GetMetrics(ctx, &pb.GetMetricsRequest{
+		ScaledObjectRef: ref,
+		MetricName:      specResp.MetricSpecs[0].MetricName,
+	})
+	if err != nil {
+		t.Fatalf("GetMetrics failed: %v", err)
+	}
+	if got := metricsResp.MetricValues[0].MetricValueFloat; got != 14 {
+		t.Errorf("GetMetrics queue depth = %v, want 14 (from vllm:num_requests_waiting)", got)
+	}
+
+	// Queue depth 14 > the vllm-queue-depth profile's activation threshold
+	// (1), so the deployment should be reported active.
+	activeResp, err := client.IsActive(ctx, ref)
+	if err != nil {
+		t.Fatalf("IsActive failed: %v", err)
+	}
+	if !activeResp.Result {
+		t.Error("IsActive() = false, want true (queue depth 14 > activation threshold 1)")
+	}
+}
+
+// A ScaledObject requesting a vLLM metric type without vllmEndpoint must
+// fail fast with a clear error rather than silently falling back to NVML.
+func TestVLLMQueueDepthE2E_MissingEndpoint(t *testing.T) {
+	devices := []gpu.Metrics{{Index: 0, GPUUtilization: 10}}
+	addr, cleanup := startTestServer(t, devices)
+	defer cleanup()
+
+	conn, client := dialScaler(t, addr)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.IsActive(ctx, &pb.ScaledObjectRef{
+		Name:           "vllm-e2e-missing-endpoint",
+		Namespace:      "ai-workloads",
+		ScalerMetadata: map[string]string{"metricType": "vllm_queue_depth"},
+	})
+	if err == nil {
+		t.Error("IsActive() with vllm_queue_depth and no vllmEndpoint should return an error")
 	}
 }


### PR DESCRIPTION
The vLLM engine-API queue depth / KV cache scaling (pkg/vllm, the vllm_queue_depth / vllm_kv_cache_usage metric types, and the vllm-queue-depth profile) was already implemented and unit-tested, but was never documented and had no end-to-end coverage, so issue #28 looked unresolved.

- README.md / docs/configuration.md: document vllmEndpoint, the two vLLM metric types, and the vllm-queue-depth profile; add a "vLLM Engine Metrics" section with usage examples.
- docs/DESIGN.md: add design notes for pkg/vllm, mark the roadmap item implemented.
- ROADMAP.md / CHANGELOG.md: mark #28 done under Unreleased.
- deploy/helm/keda-gpu-scaler/README.md: add vllm-queue-depth to the available profiles list.
- deploy/examples/vllm-queue-depth-scaledobject.yaml: new example ScaledObject using the profile + vllmEndpoint.
- tests/e2e/grpc_scaler_test.go: add TestVLLMQueueDepthE2E and TestVLLMQueueDepthE2E_MissingEndpoint, exercising the real gRPC server against a fake vLLM metrics endpoint.

Verified with go build, go vet, go test ./..., and go test -tags e2e ./tests/e2e/...

## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

Updating documentation and test cases

## Related Issue

#28 

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `make test` passes
- [x] `make lint` passes
- [x] Commits are signed off (`git commit -s`)

## Contributor Info

<!-- We recognize all contributors in CONTRIBUTORS.md and on the project page.
     Please fill in what you're comfortable sharing so we can properly credit you. -->

- **Name:**
- **Location:** <!-- optional -->
- **Company / Affiliation:** <!-- optional -->

<!-- First-time contributor? A ⭐ on the repo helps other contributors discover the project! -->
- [ ] I have starred the [keda-gpu-scaler](https://github.com/pmady/keda-gpu-scaler) repository
