### PR TITLE
feat: add Ollama profile for memory-based scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Instead of configuring raw metric thresholds, use a profile optimized for your w
 | `triton-inference` | GPU Util | 75 | 10 | NVIDIA Triton Inference Server |
 | `training` | GPU Util | 90 | 0 | Training jobs (no scale-to-zero) |
 | `batch` | Memory % | 70 | 1 | Batch inference with aggressive scale-down |
+| `ollama` | Memory % | 70 | 3 | Ollama LLM serving with scale-to-zero |
 | `distributed-training` | NVLink TX | 800 | 100 | Data-parallel training on NVLink systems |
 
 ---

--- a/deploy/examples/ollama-scaledobject.yaml
+++ b/deploy/examples/ollama-scaledobject.yaml
@@ -1,0 +1,25 @@
+# Example: ScaledObject for an Ollama deployment using the
+# pre-built ollama profile.
+#
+# Prerequisites:
+#   - keda-gpu-scaler DaemonSet running (kubectl apply -f deploy/manifests.yaml)
+#   - KEDA v2.10+ installed
+#   - A Deployment named "ollama-deployment" in the "ai-workloads" namespace
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ollama-scaler
+  namespace: ai-workloads
+spec:
+  scaleTargetRef:
+    name: ollama-deployment
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  cooldownPeriod: 60
+  triggers:
+    - type: external
+      metadata:
+        # Points to the Service created by deploy/manifests.yaml
+        scalerAddress: "keda-gpu-scaler.keda.svc.cluster.local:6000"
+        # Use the pre-built Ollama profile
+        profile: "ollama"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,7 @@ Profiles bundle defaults for common workloads. Override any parameter in the tri
 | `triton-inference` | GPU Util | 75 | 10 | NVIDIA Triton Inference Server |
 | `training` | GPU Util | 90 | 0 | Training jobs (no scale-to-zero) |
 | `batch` | Memory % | 70 | 1 | Batch inference with aggressive scale-down |
+| `ollama` | Memory % | 70 | 3 | Ollama LLM serving with scale-to-zero |
 | `distributed-training` | NVLink TX MB/s | 800 | 100 | Data-parallel training on NVLink systems |
 
 ### Using a profile

--- a/pkg/profiles/profiles.go
+++ b/pkg/profiles/profiles.go
@@ -154,6 +154,17 @@ var builtinProfiles = map[string]Profile{
 		ScaleUpStabilize:   5,
 		ScaleDownStabilize: 60,
 	},
+	"ollama": {
+		Name:               "ollama",
+		MetricName:         "keda_gpu_ollama",
+		Description:        "Ollama LLM serving — memory-based, supports scale-to-zero",
+		TargetValue:        70,
+		ActivationValue:    3,
+		MetricType:         MetricMemoryUsedPercent,
+		CooldownSeconds:    60,
+		ScaleUpStabilize:   10,
+		ScaleDownStabilize: 120,
+	},
 }
 
 // Get returns a profile by name.

--- a/pkg/profiles/profiles_test.go
+++ b/pkg/profiles/profiles_test.go
@@ -64,6 +64,13 @@ func TestGetBuiltinProfiles(t *testing.T) {
 			wantTarget: 800,
 		},
 		{
+			name:       "ollama exists",
+			profile:    "ollama",
+			wantFound:  true,
+			wantMetric: MetricMemoryUsedPercent,
+			wantTarget: 70,
+		},
+		{
 			name:      "unknown profile not found",
 			profile:   "nonexistent",
 			wantFound: false,
@@ -98,8 +105,8 @@ func TestGetBuiltinProfiles(t *testing.T) {
 
 func TestList(t *testing.T) {
 	names := List()
-	if len(names) != 6 {
-		t.Errorf("List() returned %d profiles, want 6", len(names))
+	if len(names) != 7 {
+		t.Errorf("List() returned %d profiles, want 7", len(names))
 	}
 
 	expected := map[string]bool{
@@ -109,6 +116,7 @@ func TestList(t *testing.T) {
 		"training":             false,
 		"batch":                false,
 		"distributed-training": false,
+		"ollama":               false,
 	}
 	for _, name := range names {
 		if _, ok := expected[name]; !ok {


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

Implements issue #65 by adding a builtin Ollama scaling profile for KEDA GPU autoscaling.

**Note**: Ollama is typically self-hosted and idle much of the day, so freeing the GPU when no models are loaded is the profile's main cost benefit hence I've set `minReplicaCount: 0` in the ollama example to showcase scale-to-zero.

## Related Issue

Closes #65 

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `make test` passes
- [x] `make lint` passes
- [x] Commits are signed off (`git commit -s`)

## Contributor Info

<!-- We recognize all contributors in CONTRIBUTORS.md and on the project page.
     Please fill in what you're comfortable sharing so we can properly credit you. -->

- **Name:** Pavan Sorab
- **Location:** Bangalore, India

<!-- First-time contributor? A ⭐ on the repo helps other contributors discover the project! -->
- [ ] I have starred the [keda-gpu-scaler](https://github.com/pmady/keda-gpu-scaler) repository
