### PR TITLE
test(scaler): add table-driven tests for getMetricValue aggregation

### DIFF
--- a/pkg/scaler/server_test.go
+++ b/pkg/scaler/server_test.go
@@ -428,6 +428,147 @@ func TestAggregateEmpty(t *testing.T) {
 	}
 }
 
+// TestGetMetricValue exercises getMetricValue across single/multi GPU, all
+// aggregation modes, mixed MIG/non-MIG devices, and the error edge cases.
+// Invalid metricType strings are validated in parseMetadata (see
+// TestParseMetadata), so the error paths here are empty-device-list and
+// out-of-range gpuIndex.
+func TestGetMetricValue(t *testing.T) {
+	// A single-device slice reused by the single-GPU aggregation cases: with only
+	// one value, every aggregation mode must return that same value.
+	oneDevice := []gpu.Metrics{
+		{Index: 0, UUID: "GPU-solo", Name: "A100", GPUUtilization: 42, MemoryUsedMiB: 1024, MemoryTotalMiB: 81920},
+	}
+
+	// Mixed MIG + non-MIG devices: non-MIG util 60, MIG util 20 -> avg 40, sum 80.
+	mixedDevices := []gpu.Metrics{
+		{Index: 0, Name: "A100", GPUUtilization: 60},
+		{Index: 1, Name: "MIG 3g.40gb", IsMIGInstance: true, ParentIndex: 0, MigProfile: "3g.40gb", GPUUtilization: 20},
+	}
+
+	tests := []struct {
+		name    string
+		devices []gpu.Metrics
+		cfg     scalerConfig
+		want    float64
+		wantErr bool
+	}{
+		{
+			name:    "single GPU avg returns that value",
+			devices: oneDevice,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "avg"},
+			want:    42,
+		},
+		{
+			name:    "single GPU max returns that value",
+			devices: oneDevice,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "max"},
+			want:    42,
+		},
+		{
+			name:    "single GPU min returns that value",
+			devices: oneDevice,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "min"},
+			want:    42,
+		},
+		{
+			name:    "single GPU sum returns that value",
+			devices: oneDevice,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "sum"},
+			want:    42,
+		},
+		{
+			name:    "multi GPU max",
+			devices: testDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "max"},
+			want:    80, // max(80, 30)
+		},
+		{
+			name:    "multi GPU min",
+			devices: testDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "min"},
+			want:    30, // min(80, 30)
+		},
+		{
+			name:    "multi GPU avg",
+			devices: testDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "avg"},
+			want:    55, // (80+30)/2
+		},
+		{
+			name:    "multi GPU sum",
+			devices: testDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "sum"},
+			want:    110, // 80+30
+		},
+		{
+			// "count" is not a supported aggregation mode; aggregate() falls
+			// through to its default branch, which returns the first device's
+			// value (in collector order), i.e. device 0's GPUUtilization=80.
+			name:    "unknown aggregation mode falls through to first value",
+			devices: testDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "count"},
+			want:    80,
+		},
+		{
+			name:    "empty device list errors",
+			devices: []gpu.Metrics{},
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "max"},
+			wantErr: true, // "no GPU devices found"
+		},
+		{
+			name:    "out-of-range gpuIndex errors",
+			devices: testDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: 99, aggregation: "max"},
+			wantErr: true, // mock collector CollectDevice error for index 99
+		},
+		{
+			// Aggregation is intentionally "sum" but must be IGNORED for a single
+			// indexed device: the result is device 1's raw GPUUtilization=30.
+			name:    "indexed device ignores aggregation",
+			devices: testDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: 1, aggregation: "sum"},
+			want:    30,
+		},
+		{
+			name:    "mixed MIG and non-MIG avg",
+			devices: mixedDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "avg"},
+			want:    40, // (60+20)/2
+		},
+		{
+			name:    "mixed MIG and non-MIG sum",
+			devices: mixedDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricGPUUtilization, gpuIndex: -1, aggregation: "sum"},
+			want:    80, // 60+20
+		},
+		{
+			// Different metric type proves metricType selection is independent of
+			// GPUUtilization: MemoryUsedMiB max(40960, 16384) = 40960.
+			name:    "multi GPU memory_used_mib max",
+			devices: testDevices,
+			cfg:     scalerConfig{metricType: profiles.MetricMemoryUsedMiB, gpuIndex: -1, aggregation: "max"},
+			want:    40960,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestScaler(tt.devices)
+			got, err := s.getMetricValue(tt.cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("getMetricValue() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getMetricValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // MetricType alias for the test that uses a raw string
 type MetricType = profiles.MetricType
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Test
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] CI/Build

> _Test-only change: adds unit-test coverage, no production code modified. None of the categories above map cleanly to "tests" — tick whichever your maintainers prefer._

## Description

Adds a table-driven unit test, `TestGetMetricValue`, for the GPU metric
aggregation logic in `pkg/scaler/server.go`. `getMetricValue` reduces
per-GPU metrics down to a single value that drives KEDA scaling decisions,
and its edge cases were previously under-tested.

The new test (`pkg/scaler/server_test.go`, +1 function, no production
code changed) covers **15 cases**:

- **All four aggregation modes** (`max`, `min`, `avg`, `sum`) for both a
  single-GPU set and a multi-GPU set.
- **Unknown aggregation mode** (`"count"`) — confirms it falls through to
  the first device's value rather than erroring.
- **Error edge cases** — empty device list (`no GPU devices found`) and an
  out-of-range `gpuIndex`.
- **Indexed device ignores aggregation** — a specific `gpuIndex` returns
  that device's raw value regardless of aggregation mode.
- **Mixed MIG / non-MIG** device sets (avg and sum).
- **Alternate metric type** (`memory_used_mib`) to prove metric selection
  is independent of GPU utilization.

The test reuses the existing `newTestScaler` helper and `testDevices`
fixture, and relies on the mock collector — no NVML / real GPU required.
`gofmt` clean.

### Proof — tests passing

<img width="1113" height="476" alt="Screenshot From 2026-07-12 18-22-39" src="https://github.com/user-attachments/assets/fd29337b-62ba-4a99-ae44-2635cb28af55" />

<!-- Command: go test ./pkg/scaler/... -run TestGetMetricValue -v -count=1 2>/dev/null | grep -v DEBUG -->

### Proof — tests failing under intentional regressions

To verify the tests actually catch bugs (not just pass trivially), I
temporarily introduced the following breaking changes one at a time,
confirmed the expected subtest failed, then reverted. **None of these
changes are part of this PR** — production code is unchanged.

<img width="1479" height="1221" alt="Screenshot From 2026-07-12 18-25-50" src="https://github.com/user-attachments/assets/5034e4b5-2707-4710-bdb5-41dc7c6dd84b" />



**Temporary regressions used for verification (all reverted)**

| # | Sabotage in `pkg/scaler/server.go` | Subtest that caught it |
|---|-------------------------------------|------------------------|
| 1 | `aggregate` `"max"` case: flipped `if v > max` to `if v < max` | `multi_GPU_max` → got 30, want 80 |
| 2 | `aggregate` `"avg"` case: returned `sum` instead of `sum / len(values)` | `multi_GPU_avg` → got 110, want 55 |
| 3 | `getMetricValue`: neutralised the `len(allMetrics) == 0` guard | `empty_device_list_errors` → expected error, got none |
| 4 | `extractMetric` `MetricMemoryUsedMiB` case: returned `MemoryTotalMiB` instead of `MemoryUsedMiB` | `multi_GPU_memory_used_mib_max` → got 81920, want 40960 |

Each was reverted with `git checkout pkg/scaler/server.go` and the full
suite returned to green.

## Related Issue

Fixes #106

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (if applicable) — N/A (test-only change)
- [x] `make test` passes
- [x] `make lint` passes
- [x] Commits are signed off (`git commit -s`)

## Contributor Info

- **Name:** Jason Paquette
- **Location:** Boston, MA
- **Company / Affiliation:**

## AI Assistance Disclosure

This test file was written with the assistance of an AI coding tool.
 All test cases, expected values, and edge-case
selection were reviewed and verified by a human, including running the
suite and confirming the tests fail under the intentional regressions
described above.