### PR TITLE
docs: add Helm profile examples

### DIFF
--- a/deploy/helm/keda-gpu-scaler/README.md
+++ b/deploy/helm/keda-gpu-scaler/README.md
@@ -59,6 +59,29 @@ metrics endpoint rather than GPU utilization/memory, and requires a
 `http://vllm-deployment:8000/metrics`) — see the repo's
 `docs/configuration.md#vllm-engine-metrics`.
 
+### Required and optional configuration
+
+The chart has no required value overrides for clusters whose GPU nodes expose
+the `nvidia` RuntimeClass. Common environment-specific overrides are:
+
+- `runtimeClassName`: set to `""` when the cluster has no NVIDIA RuntimeClass.
+- `nvmlHostMounts.enabled`: enable when NVML must be mounted from the host.
+- `imagePullSecrets`: set when pulling the image through a private registry.
+- `nodeSelector` and `tolerations`: adjust when GPU nodes use custom labels or
+  taints.
+
+Scaling profiles are not Helm values. Add a `profile` to the KEDA
+`ScaledObject` trigger metadata after installing the chart.
+
+### Scaling examples
+
+- [`examples/scaledobject.yaml`](examples/scaledobject.yaml): vLLM inference
+  with scale-to-zero.
+- [`examples/training-scaledobject.yaml`](examples/training-scaledobject.yaml):
+  training workers using the `training` profile and average GPU utilization.
+- [`examples/mig-scaledobject.yaml`](examples/mig-scaledobject.yaml): MIG-enabled
+  nodes using automatic instance discovery and aggregation.
+
 ## Parameters
 
 ### Image

--- a/deploy/helm/keda-gpu-scaler/examples/mig-scaledobject.yaml
+++ b/deploy/helm/keda-gpu-scaler/examples/mig-scaledobject.yaml
@@ -1,0 +1,27 @@
+# Example ScaledObject for a workload on MIG-enabled GPU nodes.
+#
+# The scaler auto-discovers MIG compute instances. Omitting gpuIndex aggregates
+# all discovered instances; adjust aggregation and thresholds for your layout.
+#
+# Usage:
+#   kubectl apply -f deploy/helm/keda-gpu-scaler/examples/mig-scaledobject.yaml
+#
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: mig-workload-scaler
+spec:
+  scaleTargetRef:
+    name: mig-workload
+  minReplicaCount: 1
+  maxReplicaCount: 14
+  pollingInterval: 30
+  cooldownPeriod: 120
+  triggers:
+    - type: external
+      metadata:
+        scalerAddress: "keda-gpu-scaler.keda.svc.cluster.local:6000"
+        metricType: "gpu_utilization"
+        targetValue: "75"
+        activationThreshold: "10"
+        aggregation: "avg"

--- a/deploy/helm/keda-gpu-scaler/examples/training-scaledobject.yaml
+++ b/deploy/helm/keda-gpu-scaler/examples/training-scaledobject.yaml
@@ -1,0 +1,25 @@
+# Example ScaledObject for a GPU training Deployment.
+#
+# The training profile targets high GPU utilization and does not activate
+# scale-to-zero. Update scaleTargetRef and scalerAddress for your cluster.
+#
+# Usage:
+#   kubectl apply -f deploy/helm/keda-gpu-scaler/examples/training-scaledobject.yaml
+#
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: gpu-training-scaler
+spec:
+  scaleTargetRef:
+    name: training-worker
+  minReplicaCount: 1
+  maxReplicaCount: 16
+  pollingInterval: 30
+  cooldownPeriod: 300
+  triggers:
+    - type: external
+      metadata:
+        scalerAddress: "keda-gpu-scaler.keda.svc.cluster.local:6000"
+        profile: "training"
+        aggregation: "avg"

--- a/deploy/helm/keda-gpu-scaler/values.yaml
+++ b/deploy/helm/keda-gpu-scaler/values.yaml
@@ -1,6 +1,9 @@
 # Default values for keda-gpu-scaler.
 # Each parameter is documented with a "# --" comment; the same descriptions are
 # rendered in the chart README's parameters table (deploy/helm/keda-gpu-scaler/README.md).
+# No overrides are required for a standard NVIDIA GPU node with the `nvidia`
+# RuntimeClass. Scaling profiles belong in KEDA ScaledObject trigger metadata,
+# not in this file; see the chart README and examples/ directory.
 
 # Container image for the scaler DaemonSet.
 image:


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactoring
- [ ] CI/Build

## Description

Clarifies which Helm values need environment-specific overrides and that scaling profiles are configured in KEDA `ScaledObject` metadata rather than chart values. Adds complete training and MIG-enabled workload examples alongside the existing vLLM example.

AI assistance was used to draft the documentation. I reviewed each change against the chart templates, scaler metadata parsing, built-in profiles, and MIG collector behavior, and ran the checks listed below.

## Related Issue

Fixes #112

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `make test` passes
- [ ] `make lint` passes
- [x] Commits are signed off (`git commit -s`)

Additional verification:
- `make helm-test`
- parsed all chart example manifests as YAML
- `pre-commit run --files deploy/helm/keda-gpu-scaler/README.md deploy/helm/keda-gpu-scaler/values.yaml deploy/helm/keda-gpu-scaler/examples/training-scaledobject.yaml deploy/helm/keda-gpu-scaler/examples/mig-scaledobject.yaml`
- `git diff --check`

## Contributor Info

- **Name:** Loi Nguyen
- **Location:** Vietnam
- **Company / Affiliation:** Vexere

- [ ] I have starred the [keda-gpu-scaler](https://github.com/pmady/keda-gpu-scaler) repository